### PR TITLE
Implement a basic digestion system

### DIFF
--- a/src/components/creatures.rs
+++ b/src/components/creatures.rs
@@ -7,6 +7,8 @@ use amethyst::{
     utils::scene::BasicScenePrefab,
 };
 
+use crate::components::digestion;
+
 #[derive(Default)]
 pub struct CarnivoreTag;
 #[derive(Default)]
@@ -97,6 +99,8 @@ pub fn create_carnivore(
         })
         .with(Wander::new(1.0))
         .with(WanderBehaviorTag)
+        .with(digestion::Fullness::new(100.0, 100.0))
+        .with(digestion::Digestion::new(5.0))
         .with(mesh.clone())
         .with(handle.clone())
         .with(local_transform)

--- a/src/components/digestion.rs
+++ b/src/components/digestion.rs
@@ -1,0 +1,33 @@
+use amethyst::{
+    ecs::{Component, DenseVecStorage},
+};
+
+pub struct Digestion {
+    // Points of fullness lost every second
+    pub nutrition_burn_rate: f32,
+}
+
+impl Component for Digestion {
+    type Storage = DenseVecStorage<Self>;
+}
+
+impl Digestion {
+    pub fn new(nutrition_burn_rate: f32) -> Digestion {
+        Digestion { nutrition_burn_rate }
+    }
+}
+
+pub struct Fullness {
+    pub max: f32,
+    pub value: f32,
+}
+
+impl Component for Fullness {
+    type Storage = DenseVecStorage<Self>;
+}
+
+impl Fullness {
+    pub fn new(initial: f32, max: f32) -> Fullness {
+        Fullness { value: initial, max }
+    }
+}

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -1,2 +1,3 @@
 pub mod creatures;
 pub mod environment;
+pub mod digestion;

--- a/src/main.rs
+++ b/src/main.rs
@@ -110,6 +110,9 @@ fn main() -> amethyst::Result<()> {
             &["movement_system"],
         )
         .with(DebugSystem, "debug_system", &["enforce_bounds_system"])
+        .with(digestion::DigestionSystem, "digestion_system", &[])
+        .with(digestion::StarvationSystem, "starvation_system", &["digestion_system"])
+        .with(digestion::DebugFullnessSystem, "debug_fullness_system", &["digestion_system"])
         .with_bundle(TransformBundle::new().with_dep(&["enforce_bounds_system"]))?
         .with_bundle(RenderBundle::new(pipe, Some(display_config)))?;
 

--- a/src/systems/digestion.rs
+++ b/src/systems/digestion.rs
@@ -1,0 +1,62 @@
+use amethyst::{core::Transform, core::Time, ecs::*};
+use amethyst::renderer::*;
+use std::f32;
+
+use crate::components::digestion::{Digestion, Fullness};
+
+pub struct DigestionSystem;
+
+impl<'s> System<'s> for DigestionSystem {
+    type SystemData = (
+        ReadStorage<'s, Digestion>,
+        WriteStorage<'s, Fullness>,
+        Read<'s, Time>,
+    );
+
+    fn run(&mut self, (digestions, mut fullnesses, time): Self::SystemData) {
+        for (digestion, fullness) in (&digestions, &mut fullnesses).join() {
+            let burned = digestion.nutrition_burn_rate * time.fixed_seconds();
+            let new_value = fullness.value - burned;
+            fullness.value = if burned < f32::EPSILON { 0.0 } else { new_value };
+        }
+    }
+}
+
+pub struct StarvationSystem;
+
+// Entities die if their fullness reaches zero (or less).
+impl<'s> System<'s> for StarvationSystem {
+    type SystemData = (
+        ReadStorage<'s, Fullness>,
+        Entities<'s>,
+    );
+
+    fn run(&mut self, (fullnesses, entities): Self::SystemData) {
+        for (fullness, entity) in (&fullnesses, &*entities).join() {
+            if fullness.value < f32::EPSILON {
+                let _ = entities.delete(entity);
+            }
+        }
+    }
+}
+
+pub struct DebugFullnessSystem;
+
+impl<'s> System<'s> for DebugFullnessSystem {
+    type SystemData = (
+        ReadStorage<'s, Fullness>,
+        ReadStorage<'s, Transform>,
+        Write<'s, DebugLines>,
+    );
+
+    fn run(&mut self, (fullnesses, locals, mut debug_lines): Self::SystemData) {
+        for (fullness, local) in (&fullnesses, &locals).join() {
+            let pos = local.translation();
+            debug_lines.draw_line(
+                [pos.x, pos.y, 0.0].into(),
+                [pos.x + fullness.value / 100.0, pos.y, 0.0].into(),
+                [0.0, 1.0, 0.0, 1.0].into(),
+            )
+        }
+    }
+}

--- a/src/systems/mod.rs
+++ b/src/systems/mod.rs
@@ -1,3 +1,4 @@
 pub mod collision;
 pub mod movement;
 pub mod wander;
+pub mod digestion;


### PR DESCRIPTION
This PR implements a basic digestion and starvation system.

Two components are added:
- `Fullness` that stores the maximum fullness and the current fullness
- `Digestion` that stores the rate at which fullness depletes

Three systems are added:
- `Digestion system` to apply the digestion and modify the fullness
- `Starvation system` to remove entities that starved to death (reached a fullness of 0)
- `Debug fullness system` to visualize debug lines indicating the entities fullness.

Note that at the moment all entities die after 20 seconds because all values are constant and all entities spawn at the same time.