### PR TITLE
Initial collision system

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -939,6 +939,7 @@ name = "evolution-island"
 version = "0.1.0"
 dependencies = [
  "amethyst 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2018"
 [dependencies]
 amethyst = "0.10.0"
 rand = "0.6.5"
+log = "0.4.6"

--- a/src/components/collider.rs
+++ b/src/components/collider.rs
@@ -1,0 +1,17 @@
+use amethyst::{
+    ecs::{Component, DenseVecStorage},
+};
+
+pub struct Circle {
+    pub radius: f32,
+}
+
+impl Component for Circle {
+    type Storage = DenseVecStorage<Self>;
+}
+
+impl Circle {
+    pub fn new(radius: f32) -> Circle {
+        Circle { radius }
+    }
+}

--- a/src/components/collider.rs
+++ b/src/components/collider.rs
@@ -1,6 +1,4 @@
-use amethyst::{
-    ecs::{Component, DenseVecStorage},
-};
+use amethyst::ecs::{Component, DenseVecStorage};
 
 pub struct Circle {
     pub radius: f32,

--- a/src/components/creatures.rs
+++ b/src/components/creatures.rs
@@ -8,6 +8,7 @@ use amethyst::{
 };
 
 use crate::components::digestion;
+use crate::components::collider;
 
 #[derive(Default)]
 pub struct CarnivoreTag;
@@ -111,7 +112,7 @@ pub fn create_carnivore(
             velocity: [0.0, 0.0, 0.0].into(),
             max_movement_speed: 1.75,
         })
-        .with(Wander::new(1.0))
+        .with(collider::Circle::new(0.45))
         .with(digestion::Fullness::new(100.0, 100.0))
         .with(digestion::Digestion::new(5.0))
         .with(mesh.clone())
@@ -143,6 +144,7 @@ pub fn create_herbivore(
             velocity: [0.0, 0.0, 0.0].into(),
             max_movement_speed: 2.0,
         })
+        .with(collider::Circle::new(0.45))
         .with(mesh.clone())
         .with(handle.clone())
         .with(transform)
@@ -165,6 +167,7 @@ pub fn create_plant(
     world
         .create_entity()
         .with(PlantTag)
+        .with(collider::Circle::new(0.8))
         .with(mesh.clone())
         .with(handle.clone())
         .with(transform)

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -1,3 +1,4 @@
 pub mod creatures;
 pub mod environment;
 pub mod digestion;
+pub mod collider;

--- a/src/systems/collision.rs
+++ b/src/systems/collision.rs
@@ -1,6 +1,13 @@
 use amethyst::{core::Transform, ecs::*};
+use amethyst::renderer::{DebugLines};
+use amethyst::shrev::{EventChannel, ReaderId};
+use std::f32;
+use log::{info};
 
 use crate::resources::world_bounds::*;
+use crate::components::creatures;
+use crate::components::collider;
+
 
 pub struct EnforceBoundsSystem;
 
@@ -21,5 +28,112 @@ impl<'s> System<'s> for EnforceBoundsSystem {
                 local.translation_mut().y = bounds.bottom;
             }
         }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct CollisionEvent {
+    pub entity_a: Entity,
+    pub entity_b: Entity,
+}
+
+impl CollisionEvent {
+    pub fn new(entity_a: Entity, entity_b: Entity) -> CollisionEvent {
+        CollisionEvent {
+            entity_a,
+            entity_b,
+        }
+    }
+}
+
+pub struct CollisionSystem;
+
+impl<'s> System<'s> for CollisionSystem {
+    type SystemData = (
+        ReadStorage<'s, collider::Circle>,
+        WriteStorage<'s, creatures::Movement>,
+        WriteStorage<'s, Transform>,
+        Entities<'s>,
+        Write<'s, EventChannel<CollisionEvent>>,
+    );
+
+
+    fn run(&mut self, (circles, mut movements, locals, entities, mut collision_events): Self::SystemData) {
+        for (circle_a, movement, local_a, entity_a) in (&circles, &mut movements, &locals, &entities).join() {
+            for (circle_b, local_b, entity_b) in (&circles, &locals, &entities).join() {
+                if entity_a == entity_b {
+                    continue;
+                }
+
+                let allowed_distance = circle_a.radius + circle_b.radius;
+                let direction = local_a.translation() - local_b.translation();
+                if direction.magnitude_squared() < allowed_distance * allowed_distance {
+                    collision_events.single_write(CollisionEvent::new(entity_a, entity_b));
+
+                    if direction.magnitude() < f32::EPSILON {
+                        movement.velocity = -movement.velocity;
+                    } else {
+                        let norm_direction = direction.normalize();
+                        movement.velocity = norm_direction * movement.velocity.magnitude();
+                    }
+                }
+            }
+        }
+    }
+}
+
+pub struct DebugColliderSystem;
+
+impl<'s> System<'s> for DebugColliderSystem {
+    type SystemData = (
+        ReadStorage<'s, collider::Circle>,
+        ReadStorage<'s, Transform>,
+        Write<'s, DebugLines>,
+    );
+
+    fn run(&mut self, (circles, locals, mut debug_lines): Self::SystemData) {
+        for (circle, local) in (&circles, &locals).join() {
+          let position = local.translation();
+            debug_lines.draw_line(
+                [position.x - circle.radius, position.y, 0.0].into(),
+                [position.x + circle.radius, position.y, 0.0].into(),
+                [1.0, 0.5, 0.5, 1.0].into(),
+            );
+                debug_lines.draw_line(
+                [position.x, position.y - circle.radius, 0.0].into(),
+                [position.x, position.y + circle.radius, 0.0].into(),
+                [1.0, 0.5, 0.5, 1.0].into(),
+            );
+        }
+    }
+}
+
+#[derive(Default)]
+pub struct DebugCollisionEventSystem {
+    event_reader: Option<ReaderId<CollisionEvent>>,
+}
+
+impl<'s> System<'s> for DebugCollisionEventSystem {
+    type SystemData = (
+       Write<'s, EventChannel<CollisionEvent>>,
+    );
+
+    fn run(&mut self, (collision_events,): Self::SystemData) {
+        let event_reader = self
+            .event_reader
+            .as_mut()
+            .expect("`DebugCollisionEventSystem::setup` was not called before `DebugCollisionEventSystem::run`");
+
+        for event in collision_events.read(event_reader) {
+            info!("Received collision event {:?}", event)
+        }
+    }
+
+    fn setup(&mut self, res: &mut Resources) {
+        Self::SystemData::setup(res);
+        self.event_reader = Some(
+            res.fetch_mut::<EventChannel<CollisionEvent>>()
+                .register_reader(),
+        );
     }
 }

--- a/src/systems/collision.rs
+++ b/src/systems/collision.rs
@@ -1,13 +1,12 @@
-use amethyst::{core::Transform, ecs::*};
-use amethyst::renderer::{DebugLines};
+use amethyst::renderer::DebugLines;
 use amethyst::shrev::{EventChannel, ReaderId};
+use amethyst::{core::Transform, ecs::*};
+use log::info;
 use std::f32;
-use log::{info};
 
-use crate::resources::world_bounds::*;
-use crate::components::creatures;
 use crate::components::collider;
-
+use crate::components::creatures;
+use crate::resources::world_bounds::*;
 
 pub struct EnforceBoundsSystem;
 
@@ -39,10 +38,7 @@ pub struct CollisionEvent {
 
 impl CollisionEvent {
     pub fn new(entity_a: Entity, entity_b: Entity) -> CollisionEvent {
-        CollisionEvent {
-            entity_a,
-            entity_b,
-        }
+        CollisionEvent { entity_a, entity_b }
     }
 }
 
@@ -57,9 +53,13 @@ impl<'s> System<'s> for CollisionSystem {
         Write<'s, EventChannel<CollisionEvent>>,
     );
 
-
-    fn run(&mut self, (circles, mut movements, locals, entities, mut collision_events): Self::SystemData) {
-        for (circle_a, movement, local_a, entity_a) in (&circles, &mut movements, &locals, &entities).join() {
+    fn run(
+        &mut self,
+        (circles, mut movements, locals, entities, mut collision_events): Self::SystemData,
+    ) {
+        for (circle_a, movement, local_a, entity_a) in
+            (&circles, &mut movements, &locals, &entities).join()
+        {
             for (circle_b, local_b, entity_b) in (&circles, &locals, &entities).join() {
                 if entity_a == entity_b {
                     continue;
@@ -93,13 +93,13 @@ impl<'s> System<'s> for DebugColliderSystem {
 
     fn run(&mut self, (circles, locals, mut debug_lines): Self::SystemData) {
         for (circle, local) in (&circles, &locals).join() {
-          let position = local.translation();
+            let position = local.translation();
             debug_lines.draw_line(
                 [position.x - circle.radius, position.y, 0.0].into(),
                 [position.x + circle.radius, position.y, 0.0].into(),
                 [1.0, 0.5, 0.5, 1.0].into(),
             );
-                debug_lines.draw_line(
+            debug_lines.draw_line(
                 [position.x, position.y - circle.radius, 0.0].into(),
                 [position.x, position.y + circle.radius, 0.0].into(),
                 [1.0, 0.5, 0.5, 1.0].into(),
@@ -114,9 +114,7 @@ pub struct DebugCollisionEventSystem {
 }
 
 impl<'s> System<'s> for DebugCollisionEventSystem {
-    type SystemData = (
-       Write<'s, EventChannel<CollisionEvent>>,
-    );
+    type SystemData = (Write<'s, EventChannel<CollisionEvent>>,);
 
     fn run(&mut self, (collision_events,): Self::SystemData) {
         let event_reader = self


### PR DESCRIPTION
This is a draft for #14 
Not implemented:
- Spawning is not modified
- Events are dispatched every iteration and only one type of collision event exists
- An entity in conflict might move in any direction

Implemented:
- Added log module for debugging
- Added `collider::Circle` component to specify radius collider of entities
- Reduced number of plants to make some space
- Added `CollisionSystem` and `DebugCollisionEventSystem` and `DebugColliderSystem` for debugging
