### PR TITLE
Don't register `Attributes` component

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -32,7 +32,6 @@ impl SimpleState for ExampleState {
         data.world.register::<creatures::HerbivoreTag>();
         data.world.register::<creatures::CarnivoreTag>();
         data.world.register::<creatures::IntelligenceTag>();
-        data.world.register::<creatures::Attributes>();
 
         data.world
             .add_resource(DebugLines::new().with_capacity(100));


### PR DESCRIPTION
The component was removed in #19 but is still registered, making it impossible to compile the project.