### PR TITLE
Initial combat system

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -269,6 +269,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "amethyst_test"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "amethyst 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "boxfnonce 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "derivative 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "derive-new 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hetseq 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "amethyst_ui"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -483,6 +496,11 @@ dependencies = [
 [[package]]
 name = "block"
 version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "boxfnonce"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -887,6 +905,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive-new"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.33 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "dirs"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -978,6 +1006,7 @@ dependencies = [
  "amethyst 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "amethyst-imgui 0.1.0 (git+https://github.com/awpteamoose/amethyst-imgui.git?branch=amethyst-v0.10)",
  "amethyst-inspector 0.1.0 (git+https://github.com/awpteamoose/amethyst-inspector.git?branch=amethyst-v0.10)",
+ "amethyst_test 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2989,6 +3018,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum amethyst_locale 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "50863c332aac57e4bedb0107589d7b3eff6291f6fc8db45b8a96fe076dff627b"
 "checksum amethyst_network 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9f3cf3e1a8275747cd502b8f309f86374fccc124cab3b2980ee117a35b70a9dd"
 "checksum amethyst_renderer 0.10.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8db2789b7767f3d1f4dde2d4e26411a3931c8b0c0f5659f915c9e15e7a6b9d6d"
+"checksum amethyst_test 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "49bfa6bcce1d452e6f52e607058191e149ad223a21bdb1ec5798000f0df2d75b"
 "checksum amethyst_ui 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b0dfdf30bfe6319b572d25d728231eb9ac076dd0e897767faa855d9616f4de2a"
 "checksum amethyst_utils 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "79b837869fd3b53b7a37fd8473ff184b23dc0d0aa6dd15ad4bc0e46a6a2551da"
 "checksum andrew 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9b7f09f89872c2b6b29e319377b1fbe91c6f5947df19a25596e121cf19a7b35e"
@@ -3011,6 +3041,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
 "checksum blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)" = "5d6d530bdd2d52966a6d03b7a964add7ae1a288d25214066fd4b600f0f796400"
 "checksum block 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
+"checksum boxfnonce 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5988cb1d626264ac94100be357308f29ff7cbdd3b36bda27f450a4ee3f713426"
 "checksum build_const 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "39092a32794787acd8525ee150305ff051b0aa6cc2abaf193924f5ab05425f39"
 "checksum byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a019b10a2a7cdeb292db131fc8113e57ea2a908f6e7894b0c3c671893b65dbeb"
 "checksum cc 1.0.35 (registry+https://github.com/rust-lang/crates.io-index)" = "5e5f3fee5eeb60324c2781f1e41286bdee933850fff9b3c672587fed5ec58c83"
@@ -3055,6 +3086,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum crossbeam-utils 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "f8306fcef4a7b563b76b7dd949ca48f52bc1141aa067d2ea09565f3e2652aa5c"
 "checksum deflate 0.7.19 (registry+https://github.com/rust-lang/crates.io-index)" = "8a6abb26e16e8d419b5c78662aa9f82857c2386a073da266840e474d5055ec86"
 "checksum derivative 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6073e9676dbebdddeabaeb63e3b7cefd23c86f5c41d381ee1237cc77b1079898"
+"checksum derive-new 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "6ca414e896ae072546f4d789f452daaecf60ddee4c9df5dc6d5936d769e3d87c"
 "checksum dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "3fd78930633bd1c6e35c4b42b1df7b0cbc6bc191146e512bb3bedf243fcc3901"
 "checksum dlib 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "77e51249a9d823a4cb79e3eca6dcd756153e8ed0157b6c04775d04bf1b13b76a"
 "checksum downcast-rs 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "f2b92dfd5c2f75260cbf750572f95d387e7ca0ba5e3fbe9e1a33f23025be020f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 
 [dependencies]
 amethyst = "0.10.0"
+amethyst_test = "0.1.0"
 rand = "0.6.5"
 log = "0.4.6"
 amethyst-imgui = { git = "https://github.com/awpteamoose/amethyst-imgui.git", branch = "amethyst-v0.10" }

--- a/src/components/combat.rs
+++ b/src/components/combat.rs
@@ -1,0 +1,197 @@
+use amethyst::core::Named;
+use amethyst::ecs::{
+    Component, DenseVecStorage, Entity, HashMapStorage, LazyUpdate, Read, ReadStorage, VecStorage,
+};
+use amethyst::prelude::*;
+use amethyst_imgui::imgui;
+use std::time::Duration;
+
+pub struct Damage {
+    // Points subtracted from target's health per hit
+    pub damage: f32,
+}
+
+impl Component for Damage {
+    type Storage = DenseVecStorage<Self>;
+}
+
+impl Damage {
+    pub fn new(damage: f32) -> Damage {
+        Damage { damage }
+    }
+}
+
+impl<'a> amethyst_inspector::Inspect<'a> for Damage {
+    type SystemData = (ReadStorage<'a, Self>,);
+
+    fn inspect((storage,): &Self::SystemData, entity: amethyst::ecs::Entity, ui: &imgui::Ui<'_>) {
+        let &Damage { mut damage } = if let Some(x) = storage.get(entity) {
+            x
+        } else {
+            return;
+        };
+        ui.drag_float(imgui::im_str!("value##damage{:?}", entity), &mut damage)
+            .build();
+        ui.separator();
+    }
+}
+
+///
+///
+///
+pub struct Speed {
+    pub attacks_per_second: f32,
+}
+
+impl Component for Speed {
+    type Storage = DenseVecStorage<Self>;
+}
+
+impl Speed {
+    pub fn new(attacks_per_second: f32) -> Speed {
+        Speed { attacks_per_second }
+    }
+}
+
+impl<'a> amethyst_inspector::Inspect<'a> for Speed {
+    type SystemData = (ReadStorage<'a, Self>,);
+
+    fn inspect((storage,): &Self::SystemData, entity: amethyst::ecs::Entity, ui: &imgui::Ui<'_>) {
+        let &Speed {
+            mut attacks_per_second,
+        } = if let Some(x) = storage.get(entity) {
+            x
+        } else {
+            return;
+        };
+        ui.drag_float(
+            imgui::im_str!("attacks per second##speed{:?}", entity),
+            &mut attacks_per_second,
+        )
+        .build();
+        ui.separator();
+    }
+}
+
+///
+///
+///
+// As long as the cooldown component is attached to an entity, that entity won't be able to attack.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Cooldown {
+    pub time_left: Duration,
+}
+
+impl Component for Cooldown {
+    type Storage = DenseVecStorage<Self>;
+}
+
+impl Cooldown {
+    pub fn new(time_left: Duration) -> Cooldown {
+        Cooldown { time_left }
+    }
+}
+
+impl<'a> amethyst_inspector::Inspect<'a> for Cooldown {
+    type SystemData = (ReadStorage<'a, Self>,);
+
+    fn inspect((storage,): &Self::SystemData, entity: amethyst::ecs::Entity, ui: &imgui::Ui<'_>) {
+        let &Cooldown { time_left } = if let Some(x) = storage.get(entity) {
+            x
+        } else {
+            return;
+        };
+        ui.drag_float(
+            imgui::im_str!("time left##cooldown{:?}", entity),
+            &mut (time_left.as_millis() as f32),
+        )
+        .build();
+        ui.separator();
+    }
+}
+
+///
+///
+///
+// Indicate whether the entity is part of a faction. Factions are used to represent groups of
+// entities that attack each other, see `HasFaction`. A faction is an entity of its own and might
+// specify properties using components.
+pub struct HasFaction {
+    pub faction: Entity,
+}
+
+impl Component for HasFaction {
+    type Storage = VecStorage<Self>;
+}
+
+impl HasFaction {
+    pub fn new(faction: Entity) -> HasFaction {
+        HasFaction { faction }
+    }
+}
+
+impl<'a> amethyst_inspector::Inspect<'a> for HasFaction {
+    type SystemData = (ReadStorage<'a, Self>,);
+
+    fn inspect((storage,): &Self::SystemData, entity: amethyst::ecs::Entity, ui: &imgui::Ui<'_>) {
+        let &HasFaction { mut faction } = if let Some(x) = storage.get(entity) {
+            x
+        } else {
+            return;
+        };
+        ui.drag_int(
+            imgui::im_str!("faction##has faction{:?}", entity),
+            &mut (faction.id() as i32),
+        )
+        .build();
+        ui.separator();
+    }
+}
+
+///
+///
+///
+#[derive(Default)]
+// Store the faction entities this component's owner is hostile towards
+pub struct FactionEnemies {
+    pub enemies: Vec<Entity>,
+}
+
+impl Component for FactionEnemies {
+    type Storage = HashMapStorage<Self>;
+}
+
+impl FactionEnemies {
+    pub fn is_enemy(&self, other: &Entity) -> bool {
+        self.enemies.contains(other)
+    }
+}
+
+///
+///
+///
+pub fn create_factions(world: &mut World) -> (Entity, Entity, Entity) {
+    let plants = world
+        .create_entity()
+        .with(Named::new("Plants"))
+        .with(FactionEnemies::default())
+        .build();
+
+    let herbivores = world
+        .create_entity()
+        .with(Named::new("Herbivores"))
+        .with(FactionEnemies {
+            enemies: vec![plants],
+        })
+        .build();
+
+    let carnivores = world
+        .create_entity()
+        .with(Named::new("Carnivores"))
+        .with(FactionEnemies {
+            enemies: vec![herbivores],
+        })
+        .build();
+
+    return (plants, herbivores, carnivores);
+}

--- a/src/components/creatures.rs
+++ b/src/components/creatures.rs
@@ -1,14 +1,16 @@
 use amethyst::{
     assets::{AssetLoaderSystemData, Handle, Prefab},
     core::{nalgebra::Vector3, transform::Transform},
-    ecs::{Component, DenseVecStorage, LazyUpdate, NullStorage, Read, ReadStorage, WriteStorage},
+    ecs::{Component, DenseVecStorage, LazyUpdate, NullStorage, Read, ReadStorage, WriteStorage, Entity},
     prelude::*,
     renderer::{Mesh, PosNormTex, PosTex, Shape},
     utils::scene::BasicScenePrefab,
 };
 
-use crate::components::digestion;
 use crate::components::collider;
+use crate::components::combat;
+use crate::components::digestion;
+use crate::components::health::Health;
 use amethyst_imgui::imgui;
 
 #[derive(Default)]
@@ -163,6 +165,7 @@ pub fn create_carnivore(
     x: f32,
     y: f32,
     handle: &Handle<Prefab<CreaturePrefabData>>,
+    faction: Entity,
 ) {
     let mut transform = Transform::default();
     transform.set_xyz(x, y, 1.0);
@@ -183,7 +186,11 @@ pub fn create_carnivore(
         })
         .with(collider::Circle::new(0.45))
         .with(digestion::Fullness::new(100.0, 100.0))
-        .with(digestion::Digestion::new(5.0))
+        .with(digestion::Digestion::new(1.0))
+        .with(Health::new(100.0))
+        .with(combat::Speed::new(1.0))
+        .with(combat::Damage::new(20.0))
+        .with(combat::HasFaction::new(faction))
         .with(mesh.clone())
         .with(handle.clone())
         .with(transform)
@@ -195,6 +202,7 @@ pub fn create_herbivore(
     x: f32,
     y: f32,
     handle: &Handle<Prefab<CreaturePrefabData>>,
+    faction: Entity,
 ) {
     let mut transform = Transform::default();
     transform.set_xyz(x, y, 1.0);
@@ -214,6 +222,12 @@ pub fn create_herbivore(
             max_movement_speed: 2.0,
         })
         .with(collider::Circle::new(0.45))
+        .with(digestion::Fullness::new(100.0, 100.0))
+        .with(digestion::Digestion::new(1.0))
+        .with(Health::new(100.0))
+        .with(combat::Speed::new(0.5))
+        .with(combat::Damage::new(20.0))
+        .with(combat::HasFaction::new(faction))
         .with(mesh.clone())
         .with(handle.clone())
         .with(transform)
@@ -225,6 +239,7 @@ pub fn create_plant(
     x: f32,
     y: f32,
     handle: &Handle<Prefab<CreaturePrefabData>>,
+    faction: Entity,
 ) {
     let mut transform = Transform::default();
     transform.set_xyz(x, y, 0.0);
@@ -238,6 +253,8 @@ pub fn create_plant(
         .named("Plant")
         .with(PlantTag)
         .with(collider::Circle::new(0.8))
+        .with(Health::new(20.0))
+        .with(combat::HasFaction::new(faction))
         .with(mesh.clone())
         .with(handle.clone())
         .with(transform)

--- a/src/components/health.rs
+++ b/src/components/health.rs
@@ -1,0 +1,44 @@
+use amethyst::ecs::{Component, DenseVecStorage, ReadStorage};
+use amethyst_imgui::imgui;
+
+pub struct Health {
+    pub max_health: f32,
+    pub value: f32,
+}
+
+impl Component for Health {
+    type Storage = DenseVecStorage<Self>;
+}
+
+impl Health {
+    pub fn new(max_health: f32) -> Health {
+        Health {
+            max_health,
+            value: max_health,
+        }
+    }
+}
+
+impl<'a> amethyst_inspector::Inspect<'a> for Health {
+    type SystemData = (ReadStorage<'a, Self>,);
+
+    fn inspect(
+        (storage,): &Self::SystemData,
+        entity: amethyst::ecs::Entity,
+        ui: &imgui::Ui<'_>,
+    ) {
+        let &Health {
+            mut value,
+            mut max_health,
+        } = if let Some(x) = storage.get(entity) {
+            x
+        } else {
+            return;
+        };
+        ui.drag_float(imgui::im_str!("max health##health{:?}", entity), &mut max_health)
+            .build();
+        ui.drag_float(imgui::im_str!("value##health{:?}", entity), &mut value)
+            .build();
+        ui.separator();
+    }
+}

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -2,3 +2,5 @@ pub mod creatures;
 pub mod environment;
 pub mod digestion;
 pub mod collider;
+pub mod combat;
+pub mod health;

--- a/src/systems/combat.rs
+++ b/src/systems/combat.rs
@@ -1,0 +1,202 @@
+use amethyst::core::Time;
+use amethyst::shrev::{EventChannel, ReaderId};
+use amethyst::{core::Transform, ecs::*, Error};
+use amethyst_test::AmethystApplication;
+
+use crate::components::combat;
+use crate::components::combat::{Cooldown, Damage, Speed};
+use crate::components::creatures::{CarnivoreTag, HerbivoreTag, PlantTag};
+use crate::components::health::Health;
+use crate::systems::collision::CollisionEvent;
+use std::time::Duration;
+
+pub struct CooldownSystem;
+
+impl<'s> System<'s> for CooldownSystem {
+    type SystemData = (WriteStorage<'s, Cooldown>, Entities<'s>, Read<'s, Time>);
+
+    fn run(&mut self, (mut cooldowns, entities, time): Self::SystemData) {
+        let mut to_remove = Vec::new();
+
+        for (mut cooldown, entity) in (&mut cooldowns, &*entities).join() {
+            match cooldown.time_left.checked_sub(time.delta_time()) {
+                Some(time_left) => {
+                    cooldown.time_left = time_left;
+                }
+                None => {
+                    to_remove.push(entity);
+                }
+            }
+        }
+
+        for entity in &to_remove {
+            cooldowns.remove(*entity);
+        }
+    }
+}
+
+///
+///
+///
+pub struct AttackEvent {
+    pub attacker: Entity,
+    pub defender: Entity,
+}
+
+#[derive(Default)]
+pub struct PerformDefaultAttackSystem {
+    event_reader: Option<ReaderId<AttackEvent>>,
+}
+
+impl<'s> System<'s> for PerformDefaultAttackSystem {
+    type SystemData = (
+        Read<'s, EventChannel<AttackEvent>>,
+        ReadStorage<'s, Damage>,
+        WriteStorage<'s, Cooldown>,
+        ReadStorage<'s, Speed>,
+        WriteStorage<'s, Health>,
+    );
+
+    fn run(
+        &mut self,
+        (attack_events, damages, mut cooldowns, speeds, mut healths): Self::SystemData,
+    ) {
+        let event_reader = self
+            .event_reader
+            .as_mut()
+            .expect("`PerformDefaultAttackSystem::setup` was not called before `PerformDefaultAttackSystem::run`");
+
+        for event in attack_events.read(event_reader) {
+            let mut attack_set = BitSet::new();
+            attack_set.add(event.attacker.id());
+            let mut defender_set = BitSet::new();
+            defender_set.add(event.defender.id());
+
+            let mut cooldown = None;
+            for (damage, _, speed, _) in (&damages, !&cooldowns, &speeds, &attack_set).join() {
+                for (mut health, _) in (&mut healths, &defender_set).join() {
+                    health.value = health.value - damage.damage;
+                    cooldown = Some(Cooldown::new(Duration::from_millis(
+                        (1000.0 / speed.attacks_per_second) as u64,
+                    )));
+                }
+            }
+
+            if let Some(value) = cooldown {
+                cooldowns.insert(event.attacker, value);
+            }
+        }
+    }
+
+    fn setup(&mut self, res: &mut Resources) {
+        Self::SystemData::setup(res);
+        self.event_reader = Some(
+            res.fetch_mut::<EventChannel<AttackEvent>>()
+                .register_reader(),
+        )
+    }
+}
+
+#[derive(Default)]
+pub struct FindAttackSystem {
+    event_reader: Option<ReaderId<CollisionEvent>>,
+}
+
+// Determine if a collision will trigger an attack. If that is the case, generate an `AttackEvent`
+impl<'s> System<'s> for FindAttackSystem {
+    type SystemData = (
+        Read<'s, EventChannel<CollisionEvent>>,
+        Write<'s, EventChannel<AttackEvent>>,
+        ReadStorage<'s, combat::HasFaction>,
+        ReadStorage<'s, combat::FactionEnemies>,
+    );
+
+    fn run(
+        &mut self,
+        (
+            collision_events,
+            mut attack_events,
+            has_faction,
+            faction_enemies,
+        ): Self::SystemData,
+    ) {
+        let event_reader = self
+            .event_reader
+            .as_mut()
+            .expect("`FindAttackSystem::setup` was not called before `FindAttackSystem::run`");
+
+        for event in collision_events.read(event_reader) {
+            let opt_factions = has_faction
+                .get(event.entity_a)
+                .and_then(|a| has_faction.get(event.entity_b).map(|b| (a, b)));
+
+            if let Some((faction_a, faction_b)) = opt_factions {
+                let enemies_a = faction_enemies.get(faction_a.faction);
+                if let Some(enemies) = enemies_a {
+                    if enemies.is_enemy(&faction_b.faction) {
+                        attack_events.single_write(AttackEvent {
+                            attacker: event.entity_a,
+                            defender: event.entity_b,
+                        });
+                    }
+                }
+
+                let enemies_b = faction_enemies.get(faction_b.faction);
+                if let Some(enemies) = enemies_b {
+                    if enemies.is_enemy(&faction_a.faction) {
+                        attack_events.single_write(AttackEvent {
+                            attacker: event.entity_b,
+                            defender: event.entity_a,
+                        });
+                    }
+                }
+            }
+        }
+    }
+
+    fn setup(&mut self, res: &mut Resources) {
+        Self::SystemData::setup(res);
+        self.event_reader = Some(
+            res.fetch_mut::<EventChannel<CollisionEvent>>()
+                .register_reader(),
+        )
+    }
+}
+
+#[test]
+fn test_cooldown_is_reduced() -> Result<(), Error> {
+    AmethystApplication::blank()
+        .with_system(CooldownSystem, "cooldown_system", &[])
+        .with_setup(|world| {
+            world
+                .create_entity()
+                .with(Cooldown::new(Duration::from_millis(5000)))
+                .build();
+        })
+        .with_assertion(|world| {
+            let entity = world.entities().entity(0);
+            let cooldowns = world.read_storage::<Cooldown>();
+            let cooldown = cooldowns.get(entity).unwrap();
+            assert!(cooldown.time_left.as_millis() < 5000);
+        })
+        .run()
+}
+
+#[test]
+fn test_cooldown_is_removed() -> Result<(), Error> {
+    AmethystApplication::blank()
+        .with_system(CooldownSystem, "cooldown_system", &[])
+        .with_setup(|world| {
+            world
+                .create_entity()
+                .with(Cooldown::new(Duration::from_millis(0)))
+                .build();
+        })
+        .with_assertion(|world| {
+            let entity = world.entities().entity(0);
+            let cooldowns = world.read_storage::<Cooldown>();
+            let cooldown = cooldowns.get(entity);
+            assert!(cooldown.is_none());
+        })
+        .run()
+}

--- a/src/systems/health.rs
+++ b/src/systems/health.rs
@@ -1,0 +1,41 @@
+use amethyst::renderer::*;
+use amethyst::{core::Time, core::Transform, ecs::*};
+use std::f32;
+
+use crate::components::health::Health;
+
+pub struct DeathByHealthSystem;
+
+// Entities die if their health reaches zero (or less).
+impl<'s> System<'s> for DeathByHealthSystem {
+    type SystemData = (ReadStorage<'s, Health>, Entities<'s>);
+
+    fn run(&mut self, (healths, entities): Self::SystemData) {
+        for (health, entity) in (&healths, &*entities).join() {
+            if health.value < f32::EPSILON {
+                let _ = entities.delete(entity);
+            }
+        }
+    }
+}
+
+pub struct DebugHealthSystem;
+
+impl<'s> System<'s> for DebugHealthSystem {
+    type SystemData = (
+        ReadStorage<'s, Health>,
+        ReadStorage<'s, Transform>,
+        Write<'s, DebugLines>,
+    );
+
+    fn run(&mut self, (healths, locals, mut debug_lines): Self::SystemData) {
+        for (health, local) in (&healths, &locals).join() {
+            let pos = local.translation();
+            debug_lines.draw_line(
+                [pos.x, pos.y + 0.5, 0.0].into(),
+                [pos.x + health.value / 100.0, pos.y + 0.5, 0.0].into(),
+                [0.0, 1.0, 0.0, 1.0].into(),
+            )
+        }
+    }
+}

--- a/src/systems/mod.rs
+++ b/src/systems/mod.rs
@@ -3,3 +3,5 @@ pub mod decision;
 pub mod movement;
 pub mod wander;
 pub mod digestion;
+pub mod combat;
+pub mod health;


### PR DESCRIPTION
My take on the combat system. This implements #9 and #8, since they are closely related.

The components should be self-explanatory, except for `HasFaction` and `FactionEnemies`. They are used to determine which entities can attack each other. I decided to implement it that way to avoid switching on the tags (`HerbivoreTag`, `CarnivoreTag`, `PlantTag`). Another idea I had was to use an enum, but that would be closed and thus unflexible.

There are three systems for attacking. One to determine if an attack happens after a collision `FindAttackSystem`, one to perform the attack `PerformDefaultAttackSystem`. They communicate with each other using events. The last one is `CooldownSystem` to remove `Cooldown` components after the cooldown finished.

