### PR TITLE
Refactor to clean the main.rs and remove warnings from compiler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@
 
 # Vim swp files
 *.swp
+
+# IntelliJ folder
+.idea

--- a/src/components/combat.rs
+++ b/src/components/combat.rs
@@ -1,6 +1,6 @@
 use amethyst::core::Named;
 use amethyst::ecs::{
-    Component, DenseVecStorage, Entity, HashMapStorage, LazyUpdate, Read, ReadStorage, VecStorage,
+    Component, DenseVecStorage, Entity, HashMapStorage, ReadStorage, VecStorage,
 };
 use amethyst::prelude::*;
 use amethyst_imgui::imgui;
@@ -134,7 +134,7 @@ impl<'a> amethyst_inspector::Inspect<'a> for HasFaction {
     type SystemData = (ReadStorage<'a, Self>,);
 
     fn inspect((storage,): &Self::SystemData, entity: amethyst::ecs::Entity, ui: &imgui::Ui<'_>) {
-        let &HasFaction { mut faction } = if let Some(x) = storage.get(entity) {
+        let &HasFaction { faction } = if let Some(x) = storage.get(entity) {
             x
         } else {
             return;

--- a/src/components/creatures.rs
+++ b/src/components/creatures.rs
@@ -1,7 +1,7 @@
 use amethyst::{
     assets::{AssetLoaderSystemData, Handle, Prefab},
     core::{nalgebra::Vector3, transform::Transform},
-    ecs::{Component, DenseVecStorage, LazyUpdate, NullStorage, Read, ReadStorage, WriteStorage, Entity},
+    ecs::{Component, DenseVecStorage, LazyUpdate, NullStorage, Read, ReadStorage, Entity},
     prelude::*,
     renderer::{Mesh, PosNormTex, PosTex, Shape},
     utils::scene::BasicScenePrefab,

--- a/src/components/digestion.rs
+++ b/src/components/digestion.rs
@@ -1,4 +1,4 @@
-use amethyst::ecs::{Component, DenseVecStorage, LazyUpdate, Read, ReadStorage, WriteStorage};
+use amethyst::ecs::{Component, DenseVecStorage, LazyUpdate, Read, ReadStorage};
 use amethyst_imgui::imgui;
 
 pub struct Digestion {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,14 +1,10 @@
-use rand::prelude::*;
-
 use amethyst;
-
-use amethyst::assets::{PrefabLoader, PrefabLoaderSystem, RonFormat};
+use amethyst::assets::PrefabLoaderSystem;
 use amethyst::{
     core::transform::{Transform, TransformBundle},
     core::Named,
-    core::Time,
     ecs::*,
-    input::{is_key_down, InputBundle},
+    input::InputBundle,
     prelude::*,
     renderer::*,
     ui::UiTransform,
@@ -21,17 +17,16 @@ mod states;
 mod systems;
 
 use crate::components::combat::{
-    create_factions, Cooldown, Damage, FactionEnemies, HasFaction, Speed,
+    Cooldown, Damage, HasFaction, Speed,
 };
 use crate::components::creatures::{
     self, CarnivoreTag, HerbivoreTag, IntelligenceTag, Movement, PlantTag, Wander,
 };
 use crate::components::digestion::{Digestion, Fullness};
 use crate::components::health::Health;
-use crate::resources::world_bounds::*;
-use crate::states::paused::PausedState;
-use crate::systems::collision::DebugCollisionEventSystem;
-use crate::systems::*;
+use crate::states::{
+    main_game::MainGameState
+};
 
 amethyst_inspector::inspector![
     Named,
@@ -55,194 +50,6 @@ amethyst_inspector::inspector![
     HiddenPropagate,
 ];
 
-struct ExampleState {
-    dispatcher: Dispatcher<'static, 'static>,
-}
-
-impl Default for ExampleState {
-    fn default() -> Self {
-        ExampleState {
-            dispatcher: DispatcherBuilder::new()
-                .with(decision::DecisionSystem, "decision_system", &[])
-                .with(wander::WanderSystem, "wander_system", &["decision_system"])
-                .with(
-                    movement::MovementSystem,
-                    "movement_system",
-                    &["wander_system"],
-                )
-                .with(
-                    collision::CollisionSystem,
-                    "collision_system",
-                    &["movement_system"],
-                )
-                .with(
-                    collision::EnforceBoundsSystem,
-                    "enforce_bounds_system",
-                    &["movement_system"],
-                )
-                .with(
-                    DebugCollisionEventSystem::default(),
-                    "debug_collision_event_system",
-                    &["collision_system"],
-                )
-                .with(collision::DebugColliderSystem, "debug_collider_system", &[])
-                .with(
-                    DebugSystem,
-                    "debug_system",
-                    &["collision_system", "enforce_bounds_system"],
-                )
-                .with(digestion::DigestionSystem, "digestion_system", &[])
-                .with(
-                    digestion::StarvationSystem,
-                    "starvation_system",
-                    &["digestion_system"],
-                )
-                .with(
-                    digestion::DebugFullnessSystem,
-                    "debug_fullness_system",
-                    &["digestion_system"],
-                )
-                .with(combat::CooldownSystem, "cooldown_system", &[])
-                .with(
-                    combat::FindAttackSystem::default(),
-                    "find_attack_system",
-                    &["cooldown_system"],
-                )
-                .with(
-                    combat::PerformDefaultAttackSystem::default(),
-                    "perform_default_attack_system",
-                    &["find_attack_system"],
-                )
-                .with(
-                    health::DeathByHealthSystem,
-                    "death_by_health_system",
-                    &["perform_default_attack_system"],
-                )
-                .with(health::DebugHealthSystem, "debug_health_system", &[])
-                .build(),
-        }
-    }
-}
-
-impl SimpleState for ExampleState {
-    fn handle_event(
-        &mut self,
-        data: StateData<'_, GameData<'_, '_>>,
-        event: StateEvent,
-    ) -> SimpleTrans {
-        if let StateEvent::Window(event) = &event {
-            if is_key_down(&event, VirtualKeyCode::P) {
-                return Trans::Push(Box::new(PausedState));
-            }
-            if is_key_down(&event, VirtualKeyCode::Add) {
-                let mut time_resource = data.world.write_resource::<Time>();
-                let current_time_scale = time_resource.time_scale();
-                time_resource.set_time_scale(2.0 * current_time_scale);
-            }
-            if is_key_down(&event, VirtualKeyCode::Subtract) {
-                let mut time_resource = data.world.write_resource::<Time>();
-                let current_time_scale = time_resource.time_scale();
-                time_resource.set_time_scale(0.5 * current_time_scale);
-            }
-        }
-
-        return Trans::None;
-    }
-
-    fn on_start(&mut self, mut data: StateData<'_, GameData<'_, '_>>) {
-        self.dispatcher.setup(&mut data.world.res);
-
-        data.world.add_resource(DebugLinesParams {
-            line_width: 1.0 / 20.0,
-        });
-
-        data.world
-            .add_resource(DebugLines::new().with_capacity(100));
-        data.world
-            .add_resource(WorldBounds::new(-12.75, 12.75, -11.0, 11.0));
-
-        let (plants, herbivores, carnivores) = create_factions(data.world);
-
-        let carnivore_sprite =
-            data.world
-                .exec(|loader: PrefabLoader<'_, creatures::CreaturePrefabData>| {
-                    loader.load("prefabs/carnivore.ron", RonFormat, (), ())
-                });
-
-        let herbivore_sprite =
-            data.world
-                .exec(|loader: PrefabLoader<'_, creatures::CreaturePrefabData>| {
-                    loader.load("prefabs/herbivore.ron", RonFormat, (), ())
-                });
-
-        for i in 0..2 {
-            for j in 0..2 {
-                let (x, y) = (4.0 * i as f32, 4.0 * j as f32);
-                creatures::create_carnivore(
-                    data.world,
-                    (x - 5.0),
-                    (y - 5.0),
-                    &carnivore_sprite,
-                    carnivores,
-                );
-            }
-        }
-
-        for i in 0..2 {
-            for j in 0..2 {
-                let (x, y) = (4.0 * i as f32, 4.0 * j as f32);
-                creatures::create_herbivore(
-                    data.world,
-                    (x - 5.0),
-                    (y - 5.0),
-                    &herbivore_sprite,
-                    herbivores,
-                );
-            }
-        }
-
-        // Add some plants
-        let plant_sprite =
-            data.world
-                .exec(|loader: PrefabLoader<'_, creatures::CreaturePrefabData>| {
-                    loader.load("prefabs/plant.ron", RonFormat, (), ())
-                });
-        let (left, right, bottom, top) = {
-            let wb = data.world.read_resource::<WorldBounds>();
-            (wb.left, wb.right, wb.bottom, wb.top)
-        };
-        let mut rng = thread_rng();
-        for _ in 0..25 {
-            let x = rng.gen_range(left, right);
-            let y = rng.gen_range(bottom, top);
-            creatures::create_plant(data.world, x, y, &plant_sprite, plants);
-        }
-
-        // Setup camera
-        let (width, height) = {
-            let dim = data.world.read_resource::<ScreenDimensions>();
-            (dim.width(), dim.height())
-        };
-
-        let mut transform = Transform::default();
-        transform.set_position([0.0, 0.0, 12.0].into());
-
-        data.world
-            .create_entity()
-            .named("Main camera")
-            .with(Camera::from(Projection::perspective(
-                width / height,
-                std::f32::consts::FRAC_PI_2,
-            )))
-            .with(transform)
-            .build();
-    }
-
-    fn update(&mut self, data: &mut StateData<'_, GameData<'_, '_>>) -> SimpleTrans {
-        self.dispatcher.dispatch(&mut data.world.res);
-        Trans::None
-    }
-}
 
 fn main() -> amethyst::Result<()> {
     amethyst::start_logger(Default::default());
@@ -291,55 +98,8 @@ fn main() -> amethyst::Result<()> {
         )
         .with_bundle(RenderBundle::new(pipe, Some(display_config)))?;
 
-    let mut game = Application::new(resources, ExampleState::default(), game_data)?;
+    let mut game = Application::new(resources, MainGameState::default(), game_data)?;
     game.run();
     Ok(())
 }
 
-struct DebugSystem;
-impl<'s> System<'s> for DebugSystem {
-    type SystemData = (Write<'s, DebugLines>, Write<'s, WorldBounds>);
-
-    fn run(&mut self, (mut debug_lines_resource, bounds): Self::SystemData) {
-        let color = [0.8, 0.04, 0.6, 1.0];
-        debug_lines_resource.draw_line(
-            [bounds.left, bounds.bottom, 0.0].into(),
-            [bounds.right, bounds.bottom, 0.0].into(),
-            color.into(),
-        );
-
-        debug_lines_resource.draw_line(
-            [bounds.left, bounds.top, 0.0].into(),
-            [bounds.right, bounds.top, 0.0].into(),
-            color.into(),
-        );
-
-        debug_lines_resource.draw_line(
-            [bounds.left, bounds.bottom, 0.0].into(),
-            [bounds.left, bounds.top, 0.0].into(),
-            color.into(),
-        );
-
-        debug_lines_resource.draw_line(
-            [bounds.right, bounds.bottom, 0.0].into(),
-            [bounds.right, bounds.top, 0.0].into(),
-            color.into(),
-        );
-
-        debug_lines_resource.draw_line(
-            [0.0, 0.0, 0.0].into(),
-            [1.0, 0.0, 0.0].into(),
-            [1.0, 0.0, 0.0, 1.0].into(),
-        );
-        debug_lines_resource.draw_line(
-            [0.0, 0.0, 0.0].into(),
-            [0.0, 1.0, 0.0].into(),
-            [0.0, 1.0, 0.0, 1.0].into(),
-        );
-        debug_lines_resource.draw_line(
-            [0.0, 0.0, 0.0].into(),
-            [0.0, 0.0, 1.0].into(),
-            [0.0, 0.0, 1.0, 1.0].into(),
-        );
-    }
-}

--- a/src/states/main_game.rs
+++ b/src/states/main_game.rs
@@ -1,0 +1,209 @@
+use rand::{
+    thread_rng,
+    Rng
+};
+use amethyst;
+use amethyst::assets::{PrefabLoader, RonFormat};
+use amethyst::{
+    core::transform::Transform,
+    core::Time,
+    ecs::*,
+    input::is_key_down,
+    prelude::*,
+    renderer::*,
+};
+
+use crate::components::combat::create_factions;
+use crate::components::creatures;
+use crate::resources::world_bounds::*;
+use crate::states::paused::PausedState;
+use crate::systems::*;
+
+pub struct MainGameState {
+    dispatcher: Dispatcher<'static, 'static>,
+}
+
+impl Default for MainGameState {
+    fn default() -> Self {
+        MainGameState {
+            dispatcher: DispatcherBuilder::new()
+                .with(decision::DecisionSystem, "decision_system", &[])
+                .with(wander::WanderSystem, "wander_system", &["decision_system"])
+                .with(
+                    movement::MovementSystem,
+                    "movement_system",
+                    &["wander_system"],
+                )
+                .with(
+                    collision::CollisionSystem,
+                    "collision_system",
+                    &["movement_system"],
+                )
+                .with(
+                    collision::EnforceBoundsSystem,
+                    "enforce_bounds_system",
+                    &["movement_system"],
+                )
+                .with(
+                    collision::DebugCollisionEventSystem::default(),
+                    "debug_collision_event_system",
+                    &["collision_system"],
+                )
+                .with(collision::DebugColliderSystem, "debug_collider_system", &[])
+                .with(
+                    debug::DebugSystem,
+                    "debug_system",
+                    &["collision_system", "enforce_bounds_system"],
+                )
+                .with(digestion::DigestionSystem, "digestion_system", &[])
+                .with(
+                    digestion::StarvationSystem,
+                    "starvation_system",
+                    &["digestion_system"],
+                )
+                .with(
+                    digestion::DebugFullnessSystem,
+                    "debug_fullness_system",
+                    &["digestion_system"],
+                )
+                .with(combat::CooldownSystem, "cooldown_system", &[])
+                .with(
+                    combat::FindAttackSystem::default(),
+                    "find_attack_system",
+                    &["cooldown_system"],
+                )
+                .with(
+                    combat::PerformDefaultAttackSystem::default(),
+                    "perform_default_attack_system",
+                    &["find_attack_system"],
+                )
+                .with(
+                    health::DeathByHealthSystem,
+                    "death_by_health_system",
+                    &["perform_default_attack_system"],
+                )
+                .with(health::DebugHealthSystem, "debug_health_system", &[])
+                .build(),
+        }
+    }
+}
+
+impl SimpleState for MainGameState {
+    fn handle_event(
+        &mut self,
+        data: StateData<'_, GameData<'_, '_>>,
+        event: StateEvent,
+    ) -> SimpleTrans {
+        if let StateEvent::Window(event) = &event {
+            if is_key_down(&event, VirtualKeyCode::P) {
+                return Trans::Push(Box::new(PausedState));
+            }
+            if is_key_down(&event, VirtualKeyCode::Add) {
+                let mut time_resource = data.world.write_resource::<Time>();
+                let current_time_scale = time_resource.time_scale();
+                time_resource.set_time_scale(2.0 * current_time_scale);
+            }
+            if is_key_down(&event, VirtualKeyCode::Subtract) {
+                let mut time_resource = data.world.write_resource::<Time>();
+                let current_time_scale = time_resource.time_scale();
+                time_resource.set_time_scale(0.5 * current_time_scale);
+            }
+        }
+
+        return Trans::None;
+    }
+
+    fn on_start(&mut self, data: StateData<'_, GameData<'_, '_>>) {
+        self.dispatcher.setup(&mut data.world.res);
+
+        data.world.add_resource(DebugLinesParams {
+            line_width: 1.0 / 20.0,
+        });
+
+        data.world
+            .add_resource(DebugLines::new().with_capacity(100));
+        data.world
+            .add_resource(WorldBounds::new(-12.75, 12.75, -11.0, 11.0));
+
+        let (plants, herbivores, carnivores) = create_factions(data.world);
+
+        let carnivore_sprite =
+            data.world
+                .exec(|loader: PrefabLoader<'_, creatures::CreaturePrefabData>| {
+                    loader.load("prefabs/carnivore.ron", RonFormat, (), ())
+                });
+
+        let herbivore_sprite =
+            data.world
+                .exec(|loader: PrefabLoader<'_, creatures::CreaturePrefabData>| {
+                    loader.load("prefabs/herbivore.ron", RonFormat, (), ())
+                });
+
+        for i in 0..2 {
+            for j in 0..2 {
+                let (x, y) = (4.0 * i as f32, 4.0 * j as f32);
+                creatures::create_carnivore(
+                    data.world,
+                    x - 5.0,
+                    y - 5.0,
+                    &carnivore_sprite,
+                    carnivores,
+                );
+            }
+        }
+
+        for i in 0..2 {
+            for j in 0..2 {
+                let (x, y) = (4.0 * i as f32, 4.0 * j as f32);
+                creatures::create_herbivore(
+                    data.world,
+                    x - 5.0,
+                    y - 5.0,
+                    &herbivore_sprite,
+                    herbivores,
+                );
+            }
+        }
+
+        // Add some plants
+        let plant_sprite =
+            data.world
+                .exec(|loader: PrefabLoader<'_, creatures::CreaturePrefabData>| {
+                    loader.load("prefabs/plant.ron", RonFormat, (), ())
+                });
+        let (left, right, bottom, top) = {
+            let wb = data.world.read_resource::<WorldBounds>();
+            (wb.left, wb.right, wb.bottom, wb.top)
+        };
+        let mut rng = thread_rng();
+        for _ in 0..25 {
+            let x = rng.gen_range(left, right);
+            let y = rng.gen_range(bottom, top);
+            creatures::create_plant(data.world, x, y, &plant_sprite, plants);
+        }
+
+        // Setup camera
+        let (width, height) = {
+            let dim = data.world.read_resource::<ScreenDimensions>();
+            (dim.width(), dim.height())
+        };
+
+        let mut transform = Transform::default();
+        transform.set_position([0.0, 0.0, 12.0].into());
+
+        data.world
+            .create_entity()
+            .named("Main camera")
+            .with(Camera::from(Projection::perspective(
+                width / height,
+                std::f32::consts::FRAC_PI_2,
+            )))
+            .with(transform)
+            .build();
+    }
+
+    fn update(&mut self, data: &mut StateData<'_, GameData<'_, '_>>) -> SimpleTrans {
+        self.dispatcher.dispatch(&mut data.world.res);
+        Trans::None
+    }
+}

--- a/src/states/mod.rs
+++ b/src/states/mod.rs
@@ -1,1 +1,2 @@
+pub mod main_game;
 pub mod paused;

--- a/src/systems/combat.rs
+++ b/src/systems/combat.rs
@@ -1,11 +1,12 @@
-use amethyst::core::Time;
-use amethyst::shrev::{EventChannel, ReaderId};
-use amethyst::{core::Transform, ecs::*, Error};
-use amethyst_test::AmethystApplication;
+use amethyst::{
+    core::Time,
+    shrev::{EventChannel, ReaderId},
+    ecs::*,
+
+};
 
 use crate::components::combat;
 use crate::components::combat::{Cooldown, Damage, Speed};
-use crate::components::creatures::{CarnivoreTag, HerbivoreTag, PlantTag};
 use crate::components::health::Health;
 use crate::systems::collision::CollisionEvent;
 use std::time::Duration;
@@ -83,7 +84,10 @@ impl<'s> System<'s> for PerformDefaultAttackSystem {
             }
 
             if let Some(value) = cooldown {
-                cooldowns.insert(event.attacker, value);
+                match cooldowns.insert(event.attacker, value) {
+                    Ok(_) => (),
+                    Err(_) => println!("Error when inserting in cooldowns"),
+                };
             }
         }
     }

--- a/src/systems/combat.rs
+++ b/src/systems/combat.rs
@@ -84,10 +84,7 @@ impl<'s> System<'s> for PerformDefaultAttackSystem {
             }
 
             if let Some(value) = cooldown {
-                match cooldowns.insert(event.attacker, value) {
-                    Ok(_) => (),
-                    Err(_) => println!("Error when inserting in cooldowns"),
-                };
+                cooldowns.insert(event.attacker, value).expect("Unreachable: we ar einserting now.");
             }
         }
     }

--- a/src/systems/debug.rs
+++ b/src/systems/debug.rs
@@ -1,0 +1,55 @@
+use amethyst::{
+    ecs::{
+        System, Write
+    },
+    renderer::DebugLines,
+};
+use crate::resources::world_bounds::WorldBounds;
+
+pub struct DebugSystem;
+impl<'s> System<'s> for DebugSystem {
+    type SystemData = (Write<'s, DebugLines>, Write<'s, WorldBounds>);
+
+    fn run(&mut self, (mut debug_lines_resource, bounds): Self::SystemData) {
+        let color = [0.8, 0.04, 0.6, 1.0];
+        debug_lines_resource.draw_line(
+            [bounds.left, bounds.bottom, 0.0].into(),
+            [bounds.right, bounds.bottom, 0.0].into(),
+            color.into(),
+        );
+
+        debug_lines_resource.draw_line(
+            [bounds.left, bounds.top, 0.0].into(),
+            [bounds.right, bounds.top, 0.0].into(),
+            color.into(),
+        );
+
+        debug_lines_resource.draw_line(
+            [bounds.left, bounds.bottom, 0.0].into(),
+            [bounds.left, bounds.top, 0.0].into(),
+            color.into(),
+        );
+
+        debug_lines_resource.draw_line(
+            [bounds.right, bounds.bottom, 0.0].into(),
+            [bounds.right, bounds.top, 0.0].into(),
+            color.into(),
+        );
+
+        debug_lines_resource.draw_line(
+            [0.0, 0.0, 0.0].into(),
+            [1.0, 0.0, 0.0].into(),
+            [1.0, 0.0, 0.0, 1.0].into(),
+        );
+        debug_lines_resource.draw_line(
+            [0.0, 0.0, 0.0].into(),
+            [0.0, 1.0, 0.0].into(),
+            [0.0, 1.0, 0.0, 1.0].into(),
+        );
+        debug_lines_resource.draw_line(
+            [0.0, 0.0, 0.0].into(),
+            [0.0, 0.0, 1.0].into(),
+            [0.0, 0.0, 1.0, 1.0].into(),
+        );
+    }
+}

--- a/src/systems/decision.rs
+++ b/src/systems/decision.rs
@@ -32,7 +32,7 @@ impl<'s> System<'s> for DecisionSystem {
         {
             let mut shortest = Vector3::<f32>::new(99999.0, 99999.0, 99999.0);
 
-            for (other_transform, entity, _) in (&transforms, &entities, &herbivore_tag).join() {
+            for (other_transform, _entity, _) in (&transforms, &entities, &herbivore_tag).join() {
                 let position = transform.translation();
                 let other_position = other_transform.translation();
 

--- a/src/systems/health.rs
+++ b/src/systems/health.rs
@@ -1,5 +1,5 @@
 use amethyst::renderer::*;
-use amethyst::{core::Time, core::Transform, ecs::*};
+use amethyst::{core::Transform, ecs::*};
 use std::f32;
 
 use crate::components::health::Health;

--- a/src/systems/mod.rs
+++ b/src/systems/mod.rs
@@ -1,3 +1,4 @@
+pub mod debug;
 pub mod collision;
 pub mod decision;
 pub mod movement;


### PR DESCRIPTION
Renamed `ExampleState` to `MainGameState` and moved it to its own file.

Cleaned up the `main.rs` file to avoid it getting too cluttered.

Removed `use` statements and made various modifications to silence compiler warnings.