### PR TITLE
Add looping background music

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 use amethyst;
 use amethyst::assets::PrefabLoaderSystem;
 use amethyst::{
+    audio::AudioBundle,
     core::transform::{Transform, TransformBundle},
     core::Named,
     ecs::*,
@@ -24,6 +25,7 @@ use crate::components::creatures::{
 };
 use crate::components::digestion::{Digestion, Fullness};
 use crate::components::health::Health;
+use crate::resources::audio::Music;
 use crate::states::{
     main_game::MainGameState
 };
@@ -50,10 +52,6 @@ amethyst_inspector::inspector![
     HiddenPropagate,
 ];
 
-<<<<<<< HEAD
-
-=======
->>>>>>> Awpteamoose-master
 fn main() -> amethyst::Result<()> {
     amethyst::start_logger(Default::default());
 
@@ -87,6 +85,7 @@ fn main() -> amethyst::Result<()> {
             &[],
         )
         .with_bundle(TransformBundle::new())?
+        .with_bundle(AudioBundle::new(|music: &mut Music| music.music.next()))?
         .with(
             amethyst_inspector::InspectorHierarchy::default(),
             "inspector_hierarchy",

--- a/src/resources/audio.rs
+++ b/src/resources/audio.rs
@@ -1,0 +1,42 @@
+use amethyst::{
+    assets::{Loader},
+    audio::{AudioSink, OggFormat, SourceHandle},
+    ecs::prelude::World,
+};
+
+use std::iter::Cycle;
+use std::vec::IntoIter;
+
+const BACKGROUND_MUSIC: &'static [&'static str] = &[
+    "assets/ambient.ogg"
+];
+
+pub struct Music {
+    pub music: Cycle<IntoIter<SourceHandle>>,
+}
+
+fn load_audio_track(loader: &Loader, world: &World, file: &str) -> SourceHandle {
+    loader.load(file, OggFormat, (), (), &world.read_resource())
+}
+
+// Initialise audio in the world. This sets up the background music
+pub fn initialise_audio(world: &mut World) {
+    let music = {
+        let loader = world.read_resource::<Loader>();
+
+        let mut sink = world.write_resource::<AudioSink>();
+        sink.set_volume(0.25);
+
+        let music = BACKGROUND_MUSIC
+            .iter()
+            .map(|file| load_audio_track(&loader, &world, &file))
+            .collect::<Vec<_>>()
+            .into_iter()
+            .cycle();
+
+        Music { music }
+    };
+
+    // Add sounds to the world
+    world.add_resource(music);
+}

--- a/src/resources/mod.rs
+++ b/src/resources/mod.rs
@@ -1,1 +1,2 @@
+pub mod audio;
 pub mod world_bounds;

--- a/src/states/main_game.rs
+++ b/src/states/main_game.rs
@@ -15,6 +15,7 @@ use amethyst::{
 
 use crate::components::combat::create_factions;
 use crate::components::creatures;
+use crate::resources::audio::initialise_audio;
 use crate::resources::world_bounds::*;
 use crate::states::paused::PausedState;
 use crate::systems::*;
@@ -124,6 +125,8 @@ impl SimpleState for MainGameState {
             .add_resource(DebugLines::new().with_capacity(100));
         data.world
             .add_resource(WorldBounds::new(-12.75, 12.75, -11.0, 11.0));
+
+        initialise_audio(data.world);
 
         let (plants, herbivores, carnivores) = create_factions(data.world);
 


### PR DESCRIPTION
I did a naive attempt at adding background music, by simply taking what was done in the pong tutorial.

I'm not really that familiar with Amethyst (nor with gamedev), since I only went through the pong tutorial myself two weeks ago.

I took the liberty to convert the `m4a` from the forum to `ogg`, since that's what the pong tutorial is using, and `m4a` isn't supported by `amethyst-audio`, by running
```
ffmpeg -i input.m4a -acodec vorbis -strict -2 -aq 60 -vn -ac 2 output.ogg
```

I also took it upon myself, to decide that lowering the volume to 25% would be good here, since the playback is pretty loud for an ambient cosy track IMO.

However, I wasn't sure where to place the audio module, but seemed like the `resources` folder was the best option, although not considering what resources are in specs, but merely looking at what was there before (although I'm assuming this is correct, since it seems to me that this instance of audio would be classified as a resource, also in specs terms)

I'm open for all kind of feedback and request for changes.

Solves https://github.com/amethyst/evoli/issues/26