### PR TITLE
amethyst-inspector updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /target
 **/*.rs.bk
+/imgui.ini
 
 # OS Specific
 .DS_Store

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,7 +81,7 @@ dependencies = [
 [[package]]
 name = "amethyst-inspector"
 version = "0.1.0"
-source = "git+https://github.com/awpteamoose/amethyst-inspector.git?branch=amethyst-v0.10#1eb97b38be15b1eb104e42b05f6b1aae4129abcd"
+source = "git+https://github.com/awpteamoose/amethyst-inspector.git?branch=amethyst-v0.10#a78edecbd8b874734d6c5bf4e952c22e907e943e"
 dependencies = [
  "amethyst 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "amethyst-imgui 0.1.0 (git+https://github.com/awpteamoose/amethyst-imgui.git?branch=amethyst-v0.10)",
@@ -95,7 +95,7 @@ dependencies = [
 [[package]]
 name = "amethyst-inspector-derive"
 version = "0.1.0"
-source = "git+https://github.com/awpteamoose/amethyst-inspector.git?branch=amethyst-v0.10#1eb97b38be15b1eb104e42b05f6b1aae4129abcd"
+source = "git+https://github.com/awpteamoose/amethyst-inspector.git?branch=amethyst-v0.10#a78edecbd8b874734d6c5bf4e952c22e907e943e"
 dependencies = [
  "darling 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 0.4.28 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,13 +81,26 @@ dependencies = [
 [[package]]
 name = "amethyst-inspector"
 version = "0.1.0"
-source = "git+https://github.com/awpteamoose/amethyst-inspector.git?branch=amethyst-v0.10#066713f06d9393f4f733ce2e0238b97735d4020a"
+source = "git+https://github.com/awpteamoose/amethyst-inspector.git?branch=amethyst-v0.10#1eb97b38be15b1eb104e42b05f6b1aae4129abcd"
 dependencies = [
  "amethyst 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "amethyst-imgui 0.1.0 (git+https://github.com/awpteamoose/amethyst-imgui.git?branch=amethyst-v0.10)",
+ "amethyst-inspector-derive 0.1.0 (git+https://github.com/awpteamoose/amethyst-inspector.git?branch=amethyst-v0.10)",
  "automod 0.1.1 (git+https://github.com/Awpteamoose/automod)",
  "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "paste 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "specs-derive 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "amethyst-inspector-derive"
+version = "0.1.0"
+source = "git+https://github.com/awpteamoose/amethyst-inspector.git?branch=amethyst-v0.10#1eb97b38be15b1eb104e42b05f6b1aae4129abcd"
+dependencies = [
+ "darling 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.33 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -886,6 +899,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "darling_core 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "darling_macro 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ident_case 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.33 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "darling_core 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.33 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "deflate"
 version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1009,6 +1054,7 @@ dependencies = [
  "amethyst_test 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smart-default 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1389,6 +1435,11 @@ dependencies = [
 [[package]]
 name = "hound"
 version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -2559,6 +2610,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "smart-default"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.33 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "smithay-client-toolkit"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2595,6 +2656,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "specs-derive"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.33 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "specs-hierarchy"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2622,6 +2693,11 @@ dependencies = [
 [[package]]
 name = "stdweb"
 version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "strsim"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -3007,6 +3083,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum amethyst 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2aeb884ea509846b98408d1c5c5524a894533bd147e66d29b7efc95c4047b73b"
 "checksum amethyst-imgui 0.1.0 (git+https://github.com/awpteamoose/amethyst-imgui.git?branch=amethyst-v0.10)" = "<none>"
 "checksum amethyst-inspector 0.1.0 (git+https://github.com/awpteamoose/amethyst-inspector.git?branch=amethyst-v0.10)" = "<none>"
+"checksum amethyst-inspector-derive 0.1.0 (git+https://github.com/awpteamoose/amethyst-inspector.git?branch=amethyst-v0.10)" = "<none>"
 "checksum amethyst_animation 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ca4306ecc8d9f0dd03bad2bd7de5e1be09dc1bd9f8163e31cd01fec1f66eaaa5"
 "checksum amethyst_assets 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ba7431483b9198bcf99434c91b3d55bc705532f3d43f96c4182e16054eeeb65"
 "checksum amethyst_audio 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b48f39fb0d5ab6d6bf61c0d2f87dc0a853defa8cc318ffa2ad1c13215f5a99ed"
@@ -3084,6 +3161,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum crossbeam-utils 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2760899e32a1d58d5abb31129f8fae5de75220bc2176e77ff7c627ae45c918d9"
 "checksum crossbeam-utils 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "677d453a17e8bd2b913fa38e8b9cf04bcdbb5be790aa294f2389661d72036015"
 "checksum crossbeam-utils 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "f8306fcef4a7b563b76b7dd949ca48f52bc1141aa067d2ea09565f3e2652aa5c"
+"checksum darling 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fcfbcb0c5961907597a7d1148e3af036268f2b773886b8bb3eeb1e1281d3d3d6"
+"checksum darling_core 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6afc018370c3bff3eb51f89256a6bdb18b4fdcda72d577982a14954a7a0b402c"
+"checksum darling_macro 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c6d8dac1c6f1d29a41c4712b4400f878cb4fcc4c7628f298dd75038e024998d1"
 "checksum deflate 0.7.19 (registry+https://github.com/rust-lang/crates.io-index)" = "8a6abb26e16e8d419b5c78662aa9f82857c2386a073da266840e474d5055ec86"
 "checksum derivative 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6073e9676dbebdddeabaeb63e3b7cefd23c86f5c41d381ee1237cc77b1079898"
 "checksum derive-new 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "6ca414e896ae072546f4d789f452daaecf60ddee4c9df5dc6d5936d769e3d87c"
@@ -3138,6 +3218,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum hetseq 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "678ce8a798c45dc999c4ebfeb7f89b6d54a7953d114f9f52746679abb9dda6ae"
 "checksum hibitset 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)" = "6527bc88f32e0d3926c7572874b2bf17a19b36978aacd0aacf75f7d27a5992d0"
 "checksum hound 3.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8a164bb2ceaeff4f42542bdb847c41517c78a60f5649671b2a07312b6e117549"
+"checksum ident_case 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 "checksum image 0.20.1 (registry+https://github.com/rust-lang/crates.io-index)" = "44665b4395d1844c96e7dc8ed5754782a1cdfd9ef458a80bbe45702681450504"
 "checksum imgui 0.0.24-pre (git+https://github.com/awpteamoose/amethyst-imgui.git?branch=amethyst-v0.10)" = "<none>"
 "checksum imgui-gfx-renderer 0.0.24-pre (git+https://github.com/awpteamoose/amethyst-imgui.git?branch=amethyst-v0.10)" = "<none>"
@@ -3273,12 +3354,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum siphasher 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "0b8de496cf83d4ed58b6be86c3a275b8602f6ffe98d3024a869e124147a9a3ac"
 "checksum slice-deque 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "d39fca478d10e201944a8e21f4393d6bfe38fa3b16a152050e4d097fe2bbf494"
 "checksum smallvec 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)" = "c4488ae950c49d403731982257768f48fada354a5203fe81f9bb6f43ca9002be"
+"checksum smart-default 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5a9dbd5f03d04e80355cbbe3ce5cf1f65c421eac575402e3d4d6e95d5a44edaa"
 "checksum smithay-client-toolkit 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "aa4899558362a65589b53313935099835acf999740915e134dff20cca7c6a28b"
 "checksum specs 0.14.3 (registry+https://github.com/rust-lang/crates.io-index)" = "de65613ada4338aa7ba71eca60eca24c60483433eec0077bc4f33cfc31f4bdf0"
+"checksum specs-derive 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a63549fa0d4a6f76e99e6634c328f25d0c9fa8ad6f8498aef74f6c35c0b269e5"
 "checksum specs-hierarchy 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1d3351f4ce84753cd19ab0cb850843ad1153d8c2c0e2f3480117a126916250"
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 "checksum stb_truetype 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "69b7df505db8e81d54ff8be4693421e5b543e08214bd8d99eb761fcb4d5668ba"
 "checksum stdweb 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ef5430c8e36b713e13b48a9f709cc21e046723fe44ce34587b73a830203b533e"
+"checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 "checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
 "checksum syn 0.13.11 (registry+https://github.com/rust-lang/crates.io-index)" = "14f9bf6292f3a61d2c716723fdb789a41bbe104168e6f496dc6497e531ea1b9b"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,4 @@ rand = "0.6.5"
 log = "0.4.6"
 amethyst-imgui = { git = "https://github.com/awpteamoose/amethyst-imgui.git", branch = "amethyst-v0.10" }
 amethyst-inspector = { git = "https://github.com/awpteamoose/amethyst-inspector.git", branch = "amethyst-v0.10" }
+smart-default = "0.5.2"

--- a/src/components/combat.rs
+++ b/src/components/combat.rs
@@ -5,7 +5,9 @@ use amethyst::ecs::{
 use amethyst::prelude::*;
 use amethyst_imgui::imgui;
 use std::time::Duration;
+use amethyst_inspector::Inspect;
 
+#[derive(Clone, Default, Inspect)]
 pub struct Damage {
     // Points subtracted from target's health per hit
     pub damage: f32,
@@ -21,24 +23,10 @@ impl Damage {
     }
 }
 
-impl<'a> amethyst_inspector::Inspect<'a> for Damage {
-    type SystemData = (ReadStorage<'a, Self>,);
-
-    fn inspect((storage,): &Self::SystemData, entity: amethyst::ecs::Entity, ui: &imgui::Ui<'_>) {
-        let &Damage { mut damage } = if let Some(x) = storage.get(entity) {
-            x
-        } else {
-            return;
-        };
-        ui.drag_float(imgui::im_str!("value##damage{:?}", entity), &mut damage)
-            .build();
-        ui.separator();
-    }
-}
-
 ///
 ///
 ///
+#[derive(Clone, Default, Inspect)]
 pub struct Speed {
     pub attacks_per_second: f32,
 }
@@ -53,31 +41,11 @@ impl Speed {
     }
 }
 
-impl<'a> amethyst_inspector::Inspect<'a> for Speed {
-    type SystemData = (ReadStorage<'a, Self>,);
-
-    fn inspect((storage,): &Self::SystemData, entity: amethyst::ecs::Entity, ui: &imgui::Ui<'_>) {
-        let &Speed {
-            mut attacks_per_second,
-        } = if let Some(x) = storage.get(entity) {
-            x
-        } else {
-            return;
-        };
-        ui.drag_float(
-            imgui::im_str!("attacks per second##speed{:?}", entity),
-            &mut attacks_per_second,
-        )
-        .build();
-        ui.separator();
-    }
-}
-
 ///
 ///
 ///
 // As long as the cooldown component is attached to an entity, that entity won't be able to attack.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Default, Inspect)]
 pub struct Cooldown {
     pub time_left: Duration,
 }
@@ -89,24 +57,6 @@ impl Component for Cooldown {
 impl Cooldown {
     pub fn new(time_left: Duration) -> Cooldown {
         Cooldown { time_left }
-    }
-}
-
-impl<'a> amethyst_inspector::Inspect<'a> for Cooldown {
-    type SystemData = (ReadStorage<'a, Self>,);
-
-    fn inspect((storage,): &Self::SystemData, entity: amethyst::ecs::Entity, ui: &imgui::Ui<'_>) {
-        let &Cooldown { time_left } = if let Some(x) = storage.get(entity) {
-            x
-        } else {
-            return;
-        };
-        ui.drag_float(
-            imgui::im_str!("time left##cooldown{:?}", entity),
-            &mut (time_left.as_millis() as f32),
-        )
-        .build();
-        ui.separator();
     }
 }
 

--- a/src/components/creatures.rs
+++ b/src/components/creatures.rs
@@ -6,6 +6,7 @@ use amethyst::{
     renderer::{Mesh, PosNormTex, PosTex, Shape},
     utils::scene::BasicScenePrefab,
 };
+use amethyst_inspector::Inspect;
 
 use crate::components::collider;
 use crate::components::combat;
@@ -13,128 +14,53 @@ use crate::components::digestion;
 use crate::components::health::Health;
 use amethyst_imgui::imgui;
 
-#[derive(Default)]
+#[derive(Default, Inspect)]
 pub struct CarnivoreTag;
 impl Component for CarnivoreTag {
     type Storage = NullStorage<Self>;
 }
-amethyst_inspector::inspect_marker!(CarnivoreTag);
 
-#[derive(Default)]
+#[derive(Default, Inspect)]
 pub struct HerbivoreTag;
 impl Component for HerbivoreTag {
     type Storage = NullStorage<Self>;
 }
-amethyst_inspector::inspect_marker!(HerbivoreTag);
 
-#[derive(Default)]
+#[derive(Default, Inspect)]
 pub struct PlantTag;
 impl Component for PlantTag {
     type Storage = NullStorage<Self>;
 }
-amethyst_inspector::inspect_marker!(PlantTag);
 
-#[derive(Default)]
+#[derive(Default, Inspect)]
 pub struct IntelligenceTag;
 impl Component for IntelligenceTag {
     type Storage = NullStorage<Self>;
 }
-amethyst_inspector::inspect_marker!(IntelligenceTag);
 
 ///
 ///
 ///
+#[derive(Clone, smart_default::SmartDefault, Inspect)]
 pub struct Movement {
+    #[default(Vector3::zeros())]
     pub velocity: Vector3<f32>,
     pub max_movement_speed: f32,
 }
 impl Component for Movement {
     type Storage = DenseVecStorage<Self>;
 }
-impl<'a> amethyst_inspector::Inspect<'a> for Movement {
-    type SystemData = (ReadStorage<'a, Self>, Read<'a, LazyUpdate>);
-    const CAN_ADD: bool = true;
-
-    fn inspect(
-        (storage, lazy): &Self::SystemData,
-        entity: amethyst::ecs::Entity,
-        ui: &imgui::Ui<'_>,
-    ) {
-        let &Movement {
-            velocity,
-            mut max_movement_speed,
-        } = if let Some(x) = storage.get(entity) {
-            x
-        } else {
-            return;
-        };
-        let mut v: [f32; 3] = velocity.into();
-        ui.drag_float3(imgui::im_str!("velocity##movement{:?}", entity,), &mut v)
-            .build();
-        ui.drag_float(
-            imgui::im_str!("max speed##movement{:?}", entity.id(),),
-            &mut max_movement_speed,
-        )
-        .build();
-        lazy.insert(
-            entity,
-            Movement {
-                velocity,
-                max_movement_speed,
-            },
-        );
-        ui.separator();
-    }
-
-    fn add((_storage, lazy): &Self::SystemData, entity: amethyst::ecs::Entity) {
-        lazy.insert(
-            entity,
-            Movement {
-                velocity: Vector3::zeros(),
-                max_movement_speed: 0.,
-            },
-        );
-    }
-}
 
 ///
 ///
 ///
+#[derive(Default, Clone, Inspect)]
 pub struct Wander {
     pub angle: f32,
     pub radius: f32,
 }
 impl Component for Wander {
     type Storage = DenseVecStorage<Self>;
-}
-impl<'a> amethyst_inspector::Inspect<'a> for Wander {
-    type SystemData = (ReadStorage<'a, Self>, Read<'a, LazyUpdate>);
-    const CAN_ADD: bool = true;
-
-    fn inspect(
-        (storage, lazy): &Self::SystemData,
-        entity: amethyst::ecs::Entity,
-        ui: &imgui::Ui<'_>,
-    ) {
-        let &Wander {
-            mut angle,
-            mut radius,
-        } = if let Some(x) = storage.get(entity) {
-            x
-        } else {
-            return;
-        };
-        ui.drag_float(imgui::im_str!("angle##wander{:?}", entity), &mut angle)
-            .build();
-        ui.drag_float(imgui::im_str!("radius##wander{:?}", entity,), &mut radius)
-            .build();
-        lazy.insert(entity, Wander { angle, radius });
-        ui.separator();
-    }
-
-    fn add((_storage, lazy): &Self::SystemData, entity: amethyst::ecs::Entity) {
-        lazy.insert(entity, Wander::new(0.));
-    }
 }
 
 impl Wander {

--- a/src/components/digestion.rs
+++ b/src/components/digestion.rs
@@ -1,6 +1,8 @@
 use amethyst::ecs::{Component, DenseVecStorage, LazyUpdate, Read, ReadStorage, WriteStorage};
 use amethyst_imgui::imgui;
+use amethyst_inspector::Inspect;
 
+#[derive(Default, Inspect, Clone)]
 pub struct Digestion {
     // Points of fullness lost every second
     pub nutrition_burn_rate: f32,
@@ -10,40 +12,13 @@ impl Component for Digestion {
     type Storage = DenseVecStorage<Self>;
 }
 
-impl<'a> amethyst_inspector::Inspect<'a> for Digestion {
-    type SystemData = (ReadStorage<'a, Self>, Read<'a, LazyUpdate>);
-    const CAN_ADD: bool = true;
-
-    fn inspect(
-        (storage, lazy): &Self::SystemData,
-        entity: amethyst::ecs::Entity,
-        ui: &imgui::Ui<'_>,
-    ) {
-        let mut burn_rate = if let Some(x) = storage.get(entity) {
-            x.nutrition_burn_rate
-        } else {
-            return;
-        };
-        ui.drag_float(
-            imgui::im_str!("nutrition burn rate##digestion{:?}", entity,),
-            &mut burn_rate,
-        )
-        .build();
-        lazy.insert(entity, Digestion::new(burn_rate));
-        ui.separator();
-    }
-
-    fn add((_storage, lazy): &Self::SystemData, entity: amethyst::ecs::Entity) {
-        lazy.insert(entity, Digestion::new(0.));
-    }
-}
-
 impl Digestion {
     pub fn new(nutrition_burn_rate: f32) -> Digestion {
         Digestion { nutrition_burn_rate }
     }
 }
 
+#[derive(Default, Debug, Inspect, Clone)]
 pub struct Fullness {
     pub max: f32,
     pub value: f32,
@@ -51,39 +26,6 @@ pub struct Fullness {
 
 impl Component for Fullness {
     type Storage = DenseVecStorage<Self>;
-}
-
-impl<'a> amethyst_inspector::Inspect<'a> for Fullness {
-    type SystemData = (ReadStorage<'a, Self>, Read<'a, LazyUpdate>);
-    const CAN_ADD: bool = true;
-
-    fn inspect(
-        (storage, lazy): &Self::SystemData,
-        entity: amethyst::ecs::Entity,
-        ui: &imgui::Ui<'_>,
-    ) {
-        let &Fullness { mut max, mut value } = if let Some(x) = storage.get(entity) {
-            x
-        } else {
-            return;
-        };
-        ui.drag_float(
-            imgui::im_str!("fullness value##fullness{:?}", entity,),
-            &mut value,
-        )
-        .build();
-        ui.drag_float(
-            imgui::im_str!("fullness max##fullness{:?}", entity,),
-            &mut max,
-        )
-        .build();
-        lazy.insert(entity, Fullness::new(value, max));
-        ui.separator();
-    }
-
-    fn add((_storage, lazy): &Self::SystemData, entity: amethyst::ecs::Entity) {
-        lazy.insert(entity, Fullness::new(0., 0.));
-    }
 }
 
 impl Fullness {

--- a/src/components/health.rs
+++ b/src/components/health.rs
@@ -1,6 +1,8 @@
 use amethyst::ecs::{Component, DenseVecStorage, ReadStorage};
 use amethyst_imgui::imgui;
+use amethyst_inspector::Inspect;
 
+#[derive(Clone, Default, Inspect)]
 pub struct Health {
     pub max_health: f32,
     pub value: f32,
@@ -16,29 +18,5 @@ impl Health {
             max_health,
             value: max_health,
         }
-    }
-}
-
-impl<'a> amethyst_inspector::Inspect<'a> for Health {
-    type SystemData = (ReadStorage<'a, Self>,);
-
-    fn inspect(
-        (storage,): &Self::SystemData,
-        entity: amethyst::ecs::Entity,
-        ui: &imgui::Ui<'_>,
-    ) {
-        let &Health {
-            mut value,
-            mut max_health,
-        } = if let Some(x) = storage.get(entity) {
-            x
-        } else {
-            return;
-        };
-        ui.drag_float(imgui::im_str!("max health##health{:?}", entity), &mut max_health)
-            .build();
-        ui.drag_float(imgui::im_str!("value##health{:?}", entity), &mut value)
-            .build();
-        ui.separator();
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -152,6 +152,8 @@ impl SimpleState for ExampleState {
     fn on_start(&mut self, mut data: StateData<'_, GameData<'_, '_>>) {
         self.dispatcher.setup(&mut data.world.res);
 
+        data.world.add_resource(amethyst_imgui::ImguiIni::new("imgui.ini"));
+
         data.world.add_resource(DebugLinesParams {
             line_width: 1.0 / 20.0,
         });
@@ -278,7 +280,7 @@ fn main() -> amethyst::Result<()> {
         )
         .with_bundle(TransformBundle::new())?
         .with(
-            amethyst_inspector::InspectorHierarchy,
+            amethyst_inspector::InspectorHierarchy::default(),
             "inspector_hierarchy",
             &[],
         )


### PR DESCRIPTION
Hey, I'm brining another amethyst-inspector update.

* drag entities across the hierarchy to parent them
* right click on inspector fields to set them to base value
* save imgui window positions between game launches
* `#[derive(Inspect)]`
    * also can use `#[inspect(null_to = 10., speed = 0.1)]` to change drag speed and set the base value
    * also can `#[inspect(skip)]` on fields
    * can implement `amethyst_inspector::InspectControl` on custom types to have specialised drawers