### PR TITLE
Add dynamic factions & remove plant/herbivore/carnivore tags

### DIFF
--- a/resources/prefabs/carnivore.ron
+++ b/resources/prefabs/carnivore.ron
@@ -47,7 +47,6 @@ Prefab (
                         faction: "Carnivores",
                     ),
                 ),
-                carnivore_tag: (),
                 intelligence_tag: (),
             ),
         ),

--- a/resources/prefabs/carnivore.ron
+++ b/resources/prefabs/carnivore.ron
@@ -42,8 +42,10 @@ Prefab (
                     ),
                     damage: (
                         damage: 20.0,
-                   ),
-                   faction: Carnivore,
+                    ),
+                    has_faction: (
+                        faction: "Carnivores",
+                    ),
                 ),
                 carnivore_tag: (),
                 intelligence_tag: (),

--- a/resources/prefabs/herbivore.ron
+++ b/resources/prefabs/herbivore.ron
@@ -42,8 +42,10 @@ Prefab (
                     ),
                     damage: (
                         damage: 20.0,
-                   ),
-                   faction: Herbivore,
+                    ),
+                    has_faction: (
+                        faction: "Herbivores",
+                    ),
                 ),
                 herbivore_tag: (),
                 intelligence_tag: (),

--- a/resources/prefabs/herbivore.ron
+++ b/resources/prefabs/herbivore.ron
@@ -47,7 +47,6 @@ Prefab (
                         faction: "Herbivores",
                     ),
                 ),
-                herbivore_tag: (),
                 intelligence_tag: (),
             ),
         ),

--- a/resources/prefabs/plant.ron
+++ b/resources/prefabs/plant.ron
@@ -20,7 +20,9 @@ Prefab (
                         max_health: 20.0,
                         value: 20.0,
                     ),
-                   faction: Plant,
+                    has_faction: (
+                        faction: "Plants",
+                    ),
                 ),
                 plant_tag: (),
             ),

--- a/resources/prefabs/plant.ron
+++ b/resources/prefabs/plant.ron
@@ -24,7 +24,6 @@ Prefab (
                         faction: "Plants",
                     ),
                 ),
-                plant_tag: (),
             ),
         ),
     ],

--- a/src/components/combat.rs
+++ b/src/components/combat.rs
@@ -1,11 +1,15 @@
+use amethyst::ecs::error::Error;
 use amethyst::{
     assets::{PrefabData, PrefabError, ProgressCounter},
+    core::Named,
     derive::PrefabData,
-    ecs::{Component, DenseVecStorage, Entity, ReadStorage, VecStorage, WriteStorage},
+    ecs::{Component, DenseVecStorage, Entity, HashMapStorage, Read, WriteStorage},
+    prelude::*,
 };
-use amethyst_imgui::imgui;
 use amethyst_inspector::Inspect;
+use log::error;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::time::Duration;
 
 #[derive(Default, Debug, Inspect, Clone, Deserialize, Serialize, PrefabData)]
@@ -84,65 +88,92 @@ impl Cooldown {
     }
 }
 
-#[derive(PartialEq, Eq, Debug, Clone, Deserialize, Serialize, PrefabData)]
-#[prefab(Component)]
-pub enum Faction {
-    Carnivore,
-    Herbivore,
-    Plant,
-}
-
-impl Component for Faction {
-    type Storage = VecStorage<Self>;
-}
-
-impl Faction {
-    pub fn is_enemy(&self, other: &Self) -> bool {
-        match self {
-            Faction::Carnivore => *other == Faction::Herbivore,
-            Faction::Herbivore => *other == Faction::Plant,
-            Faction::Plant => false,
-        }
-    }
-}
-
 ///
 ///
 ///
 // Indicate whether the entity is part of a faction. Factions are used to represent groups of
 // entities that attack each other, see `HasFaction`. A faction is an entity of its own and might
 // specify properties using components.
-#[derive(Debug, Clone)]
-pub struct HasFaction {
-    pub faction: Entity,
+#[derive(Default, Debug, PartialEq, Eq, Clone, Deserialize, Serialize)]
+pub struct HasFaction<T> {
+    pub faction: T,
 }
 
-impl Component for HasFaction {
-    type Storage = VecStorage<Self>;
+impl Component for HasFaction<Entity> {
+    type Storage = DenseVecStorage<Self>;
 }
 
-impl HasFaction {
-    pub fn new(faction: Entity) -> HasFaction {
-        HasFaction { faction }
+impl<'a> PrefabData<'a> for HasFaction<String> {
+    type SystemData = (
+        WriteStorage<'a, HasFaction<Entity>>,
+        Read<'a, HashMap<String, Entity>>,
+    );
+    type Result = ();
+
+    fn add_to_entity(
+        &self,
+        entity: Entity,
+        system_data: &mut Self::SystemData,
+        _entities: &[Entity],
+    ) -> Result<Self::Result, Error> {
+        let faction = system_data.1.get(self.faction.as_str());
+        if let Some(f) = faction {
+            system_data
+                .0
+                .insert(entity, HasFaction { faction: *f })
+                .expect("Unreachable: we are inserting now.");
+            return Ok(());
+        }
+
+        error!("Failed to load faction data");
+        Ok(())
     }
 }
 
-impl<'a> amethyst_inspector::Inspect<'a> for HasFaction {
-    type SystemData = (ReadStorage<'a, Self>,);
+// Store the faction entities this component's owner is hostile towards
+#[derive(Default, Debug, PartialEq, Eq, Clone)]
+pub struct FactionEnemies {
+    pub enemies: Vec<Entity>,
+}
 
-    fn inspect((storage,): &Self::SystemData, entity: amethyst::ecs::Entity, ui: &imgui::Ui<'_>) {
-        let &HasFaction { faction } = if let Some(x) = storage.get(entity) {
-            x
-        } else {
-            return;
-        };
-        ui.drag_int(
-            imgui::im_str!("faction##has faction{:?}", entity),
-            &mut (faction.id() as i32),
-        )
+impl Component for FactionEnemies {
+    type Storage = HashMapStorage<Self>;
+}
+
+impl FactionEnemies {
+    pub fn is_enemy(&self, other: &Entity) -> bool {
+        self.enemies.contains(other)
+    }
+}
+
+pub fn create_factions(world: &mut World) {
+    let plants = world
+        .create_entity()
+        .with(Named::new("Plants"))
+        .with(FactionEnemies::default())
         .build();
-        ui.separator();
-    }
+
+    let herbivores = world
+        .create_entity()
+        .with(Named::new("Herbivores"))
+        .with(FactionEnemies {
+            enemies: vec![plants],
+        })
+        .build();
+
+    let carnivores = world
+        .create_entity()
+        .with(Named::new("Carnivores"))
+        .with(FactionEnemies {
+            enemies: vec![herbivores],
+        })
+        .build();
+
+    let mut factions = HashMap::new();
+    factions.insert("Plants".to_string(), plants);
+    factions.insert("Herbivores".to_string(), herbivores);
+    factions.insert("Carnivores".to_string(), carnivores);
+    world.add_resource(factions);
 }
 
 #[derive(Default, Debug, Clone, Deserialize, Serialize, PrefabData)]
@@ -152,5 +183,5 @@ pub struct CombatPrefabData {
     health: Option<Health>,
     speed: Option<Speed>,
     damage: Option<Damage>,
-    faction: Option<Faction>,
+    has_faction: Option<HasFaction<String>>,
 }

--- a/src/components/combat.rs
+++ b/src/components/combat.rs
@@ -116,7 +116,7 @@ impl<'a> PrefabData<'a> for HasFaction<String> {
         system_data: &mut Self::SystemData,
         _entities: &[Entity],
     ) -> Result<Self::Result, Error> {
-        let faction = system_data.1.get(self.faction.as_str());
+        let faction = system_data.1.get(&self.faction);
         if let Some(f) = faction {
             system_data
                 .0

--- a/src/components/combat.rs
+++ b/src/components/combat.rs
@@ -104,10 +104,7 @@ impl Component for HasFaction<Entity> {
 }
 
 impl<'a> PrefabData<'a> for HasFaction<String> {
-    type SystemData = (
-        WriteStorage<'a, HasFaction<Entity>>,
-        Read<'a, HashMap<String, Entity>>,
-    );
+    type SystemData = (WriteStorage<'a, HasFaction<Entity>>, Read<'a, Factions>);
     type Result = ();
 
     fn add_to_entity(
@@ -116,7 +113,7 @@ impl<'a> PrefabData<'a> for HasFaction<String> {
         system_data: &mut Self::SystemData,
         _entities: &[Entity],
     ) -> Result<Self::Result, Error> {
-        let faction = system_data.1.get(&self.faction);
+        let faction = (system_data.1).0.get(&self.faction);
         if let Some(f) = faction {
             system_data
                 .0
@@ -146,6 +143,9 @@ impl FactionEnemies {
     }
 }
 
+#[derive(Default)]
+pub struct Factions(HashMap<String, Entity>);
+
 pub fn create_factions(world: &mut World) {
     let plants = world
         .create_entity()
@@ -173,7 +173,7 @@ pub fn create_factions(world: &mut World) {
     factions.insert("Plants".to_string(), plants);
     factions.insert("Herbivores".to_string(), herbivores);
     factions.insert("Carnivores".to_string(), carnivores);
-    world.add_resource(factions);
+    world.add_resource(Factions(factions));
 }
 
 #[derive(Default, Debug, Clone, Deserialize, Serialize, PrefabData)]

--- a/src/components/creatures.rs
+++ b/src/components/creatures.rs
@@ -13,33 +13,7 @@ use crate::components::{
     collider::Circle, combat::CombatPrefabData, digestion::DigestionPrefabData,
 };
 
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
-pub enum CreatureType {
-    Carnivore,
-    Herbivore,
-    Plant,
-}
-
-#[derive(Clone, Copy, Debug, Default, Deserialize, Serialize, PrefabData, Inspect)]
-#[prefab(Component)]
-pub struct CarnivoreTag;
-impl Component for CarnivoreTag {
-    type Storage = NullStorage<Self>;
-}
-
-#[derive(Clone, Copy, Debug, Default, Deserialize, Serialize, PrefabData, Inspect)]
-#[prefab(Component)]
-pub struct HerbivoreTag;
-impl Component for HerbivoreTag {
-    type Storage = NullStorage<Self>;
-}
-
-#[derive(Clone, Copy, Debug, Default, Deserialize, Serialize, PrefabData, Inspect)]
-#[prefab(Component)]
-pub struct PlantTag;
-impl Component for PlantTag {
-    type Storage = NullStorage<Self>;
-}
+pub type CreatureType = String;
 
 #[derive(Clone, Copy, Debug, Default, Deserialize, Serialize, PrefabData, Inspect)]
 #[prefab(Component)]
@@ -107,11 +81,5 @@ pub struct CreaturePrefabData {
     collider: Option<Circle>,
     digestion: Option<DigestionPrefabData>,
     combat: Option<CombatPrefabData>,
-
-    // Tags for carnivores and herbivores
-    // Should probably be reworked to avoid having too many fields here.
-    carnivore_tag: Option<CarnivoreTag>,
-    herbivore_tag: Option<HerbivoreTag>,
-    plant_tag: Option<PlantTag>,
     intelligence_tag: Option<IntelligenceTag>,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,9 +22,7 @@ mod systems;
 
 use crate::components::combat::Health;
 use crate::components::combat::{Cooldown, Damage, Speed};
-use crate::components::creatures::{
-    self, IntelligenceTag, Movement, Wander,
-};
+use crate::components::creatures::{self, IntelligenceTag, Movement, Wander};
 use crate::components::digestion::{Digestion, Fullness};
 use crate::resources::audio::Music;
 use crate::states::{main_game::MainGameState, CustomStateEvent, CustomStateEventReader};

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,7 +23,7 @@ mod systems;
 use crate::components::combat::Health;
 use crate::components::combat::{Cooldown, Damage, Speed};
 use crate::components::creatures::{
-    self, CarnivoreTag, HerbivoreTag, IntelligenceTag, Movement, PlantTag, Wander,
+    self, IntelligenceTag, Movement, Wander,
 };
 use crate::components::digestion::{Digestion, Fullness};
 use crate::resources::audio::Music;
@@ -42,9 +42,6 @@ amethyst_inspector::inspector![
     Speed,
     Cooldown,
     Health,
-    CarnivoreTag,
-    HerbivoreTag,
-    PlantTag,
     IntelligenceTag,
     Hidden,
     HiddenPropagate,

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,7 @@ mod states;
 mod systems;
 
 use crate::components::combat::Health;
-use crate::components::combat::{Cooldown, Damage, HasFaction, Speed};
+use crate::components::combat::{Cooldown, Damage, Speed};
 use crate::components::creatures::{
     self, CarnivoreTag, HerbivoreTag, IntelligenceTag, Movement, PlantTag, Wander,
 };
@@ -41,7 +41,6 @@ amethyst_inspector::inspector![
     Damage,
     Speed,
     Cooldown,
-    HasFaction,
     Health,
     CarnivoreTag,
     HerbivoreTag,

--- a/src/resources/prefabs.rs
+++ b/src/resources/prefabs.rs
@@ -41,8 +41,8 @@ pub fn initialize_prefabs(world: &mut World) {
                 loader.load("prefabs/plant.ron", RonFormat, (), ()),
             )
         });
-    creature_prefabs.insert(CreatureType::Carnivore, carnivore_prefab);
-    creature_prefabs.insert(CreatureType::Herbivore, herbivore_prefab);
-    creature_prefabs.insert(CreatureType::Plant, plant_prefab);
+    creature_prefabs.insert("Carnivore".to_string(), carnivore_prefab);
+    creature_prefabs.insert("Herbivore".to_string(), herbivore_prefab);
+    creature_prefabs.insert("Plant".to_string(), plant_prefab);
     world.add_resource(creature_prefabs);
 }

--- a/src/states/main_game.rs
+++ b/src/states/main_game.rs
@@ -13,7 +13,6 @@ use rand::{thread_rng, Rng};
 
 use crate::components::combat::create_factions;
 use crate::{
-    components::creatures::CreatureType,
     resources::{audio::initialise_audio, prefabs::initialize_prefabs, world_bounds::WorldBounds},
     states::{paused::PausedState, CustomStateEvent},
     systems::*,
@@ -177,7 +176,7 @@ impl<'a> State<GameData<'a, 'a>, CustomStateEvent> for MainGameState {
                 transform.set_scale(scale, scale, 1.0);
                 transform.set_rotation_euler(0.0, 0.0, rotation);
                 spawn_events.single_write(spawner::CreatureSpawnEvent {
-                    creature_type: CreatureType::Plant,
+                    creature_type: "Plant".to_string(),
                     transform,
                 });
             }

--- a/src/states/main_game.rs
+++ b/src/states/main_game.rs
@@ -11,6 +11,7 @@ use amethyst::{
 };
 use rand::{thread_rng, Rng};
 
+use crate::components::combat::create_factions;
 use crate::{
     components::creatures::CreatureType,
     resources::{audio::initialise_audio, prefabs::initialize_prefabs, world_bounds::WorldBounds},
@@ -148,6 +149,8 @@ impl<'a> State<GameData<'a, 'a>, CustomStateEvent> for MainGameState {
             .add_resource(DebugLines::new().with_capacity(100));
         data.world
             .add_resource(WorldBounds::new(-12.75, 12.75, -11.0, 11.0));
+
+        create_factions(data.world);
 
         initialise_audio(data.world);
         time_control::create_time_control_ui(&mut data.world);

--- a/src/systems/decision.rs
+++ b/src/systems/decision.rs
@@ -3,8 +3,8 @@ use amethyst::core::transform::Transform;
 use amethyst::core::Time;
 use amethyst::ecs::*;
 
+use crate::components::combat::{FactionEnemies, HasFaction};
 use crate::components::creatures::*;
-use crate::components::combat::{HasFaction, FactionEnemies};
 
 pub struct DecisionSystem;
 impl<'s> System<'s> for DecisionSystem {
@@ -23,13 +23,8 @@ impl<'s> System<'s> for DecisionSystem {
         (entities, mut movements, transforms, has_faction, faction_enemies, intelligence_tag, time): Self::SystemData,
     ) {
         let delta_time = time.delta_seconds();
-        for (movement, transform, faction, _) in (
-            &mut movements,
-            &transforms,
-            &has_faction,
-            &intelligence_tag,
-        )
-            .join()
+        for (movement, transform, faction, _) in
+            (&mut movements, &transforms, &has_faction, &intelligence_tag).join()
         {
             let enemies_opt = faction_enemies.get(faction.faction);
             if enemies_opt.is_none() {
@@ -41,7 +36,9 @@ impl<'s> System<'s> for DecisionSystem {
 
             let enemies = enemies_opt.unwrap();
 
-            for (other_transform, _entity, enemy_faction) in (&transforms, &entities, &has_faction).join() {
+            for (other_transform, _entity, enemy_faction) in
+                (&transforms, &entities, &has_faction).join()
+            {
                 if !enemies.is_enemy(&enemy_faction.faction) {
                     continue;
                 }

--- a/src/systems/decision.rs
+++ b/src/systems/decision.rs
@@ -4,6 +4,7 @@ use amethyst::core::Time;
 use amethyst::ecs::*;
 
 use crate::components::creatures::*;
+use crate::components::combat::{HasFaction, FactionEnemies};
 
 pub struct DecisionSystem;
 impl<'s> System<'s> for DecisionSystem {
@@ -11,28 +12,40 @@ impl<'s> System<'s> for DecisionSystem {
         Entities<'s>,
         WriteStorage<'s, Movement>,
         ReadStorage<'s, Transform>,
-        ReadStorage<'s, CarnivoreTag>,
-        ReadStorage<'s, HerbivoreTag>,
+        ReadStorage<'s, HasFaction<Entity>>,
+        ReadStorage<'s, FactionEnemies>,
         ReadStorage<'s, IntelligenceTag>,
         Read<'s, Time>,
     );
 
     fn run(
         &mut self,
-        (entities, mut movements, transforms, carnivore_tag, herbivore_tag, intelligence_tag, time): Self::SystemData,
+        (entities, mut movements, transforms, has_faction, faction_enemies, intelligence_tag, time): Self::SystemData,
     ) {
         let delta_time = time.delta_seconds();
-        for (movement, transform, _, _) in (
+        for (movement, transform, faction, _) in (
             &mut movements,
             &transforms,
-            &carnivore_tag,
+            &has_faction,
             &intelligence_tag,
         )
             .join()
         {
+            let enemies_opt = faction_enemies.get(faction.faction);
+            if enemies_opt.is_none() {
+                continue;
+            }
+
             let mut shortest: Option<Vector3<f32>> = None;
             let mut min_sq_distance = 5.0f32.powi(2);
-            for (other_transform, _entity, _) in (&transforms, &entities, &herbivore_tag).join() {
+
+            let enemies = enemies_opt.unwrap();
+
+            for (other_transform, _entity, enemy_faction) in (&transforms, &entities, &has_faction).join() {
+                if !enemies.is_enemy(&enemy_faction.faction) {
+                    continue;
+                }
+
                 let position = transform.translation();
                 let other_position = other_transform.translation();
                 let difference = other_position - position;

--- a/src/systems/spawner.rs
+++ b/src/systems/spawner.rs
@@ -26,9 +26,15 @@ struct CreatureTypeDistribution {
 impl Distribution<CreatureTypeDistribution> for Standard {
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> CreatureTypeDistribution {
         match rng.gen_range(0, 3) {
-            0 => CreatureTypeDistribution { creature_type: "Carnivore".to_string() },
-            1 => CreatureTypeDistribution { creature_type: "Herbivore".to_string() },
-            _ => CreatureTypeDistribution { creature_type: "Plant".to_string() },
+            0 => CreatureTypeDistribution {
+                creature_type: "Carnivore".to_string(),
+            },
+            1 => CreatureTypeDistribution {
+                creature_type: "Herbivore".to_string(),
+            },
+            _ => CreatureTypeDistribution {
+                creature_type: "Plant".to_string(),
+            },
         }
     }
 }
@@ -90,7 +96,8 @@ impl<'s> System<'s> for DebugSpawnTriggerSystem {
             let y = (rng.next_u32() % 100) as f32 / 5.0 - 10.0;
             let mut transform = Transform::default();
             transform.set_xyz(x, y, 0.02);
-            let CreatureTypeDistribution { creature_type }: CreatureTypeDistribution = rand::random();
+            let CreatureTypeDistribution { creature_type }: CreatureTypeDistribution =
+                rand::random();
 
             match creature_type {
                 _ if creature_type == "Carnivore" || creature_type == "Herbivore" => {


### PR DESCRIPTION
Dynamic factions allow us to specify gameplay behaviour using data and allow us to be more flexible. It is not possible to reference entities in prefabs, so we are using the `Named` component and a custom `PrefabData` implementation