### PR TITLE
Add a menu screen #48

### DIFF
--- a/resources/prefabs/ui/menu.ron
+++ b/resources/prefabs/ui/menu.ron
@@ -1,0 +1,56 @@
+#![enable(implicit_some)]
+Container(
+    transform: (
+        id: "menu",
+        anchor: Middle,
+        stretch: XY( x_margin: 0.0, y_margin: 0.0, keep_aspect_ratio: false),
+        width: 1000.0,
+        height: 1000.0,
+    ),
+    children: [
+        Button(
+            transform: (
+                id: "start",
+                x: 0.0,
+                y: 50.0,
+                width: 300.0,
+                height: 75.0,
+                anchor: Middle,
+                mouse_reactive: true,
+            ),
+            button: (
+                text: "Start",
+                font: File("assets/fonts/OpenSans-Regular.ttf", Ttf, ()),
+                font_size: 100.0,
+                normal_image: Data(Rgba((0.5, 0.5, 0.5, 1.0), (dynamic:false, channel:Srgb))),
+                hover_image: Data(Rgba((0.5, 0.5, 0.5, 1.), (dynamic:false, channel:Srgb))),
+                press_image: Data(Rgba((0.5, 0.5, 0.5, 1.), (dynamic:false, channel:Srgb))),
+                normal_text_color: (0.4, 0.4, 0.4, 1.0),
+                hover_text_color: (0.7, 0.7, 0.7, 1.0),
+                press_text_color: (0.0, 0.0, 0.0, 1.0),
+            )
+        ),
+        Button(
+            transform: (
+                id: "exit",
+                x: 0.0,
+                y: -50.0,
+                width: 300.0,
+                height: 75.0,
+                anchor: Middle,
+                mouse_reactive: true,
+            ),
+            button: (
+                text: "Exit",
+                font: File("assets/fonts/OpenSans-Regular.ttf", Ttf, ()),
+                font_size: 100.0,
+                normal_image: Data(Rgba((0.5, 0.5, 0.5, 1.0), (dynamic:false, channel:Srgb))),
+                hover_image: Data(Rgba((0.5, 0.5, 0.5, 1.), (dynamic:false, channel:Srgb))),
+                press_image: Data(Rgba((0.5, 0.5, 0.5, 1.), (dynamic:false, channel:Srgb))),
+                normal_text_color: (0.4, 0.4, 0.4, 1.0),
+                hover_text_color: (0.7, 0.7, 0.7, 1.0),
+                press_text_color: (0.0, 0.0, 0.0, 1.0),
+            )
+        ),
+    ]
+)

--- a/src/resources/prefabs.rs
+++ b/src/resources/prefabs.rs
@@ -9,7 +9,6 @@ use amethyst::{
     utils::application_root_dir,
 };
 
-
 #[derive(Default)]
 pub struct UiPrefabRegistry {
     pub prefabs: Vec<Handle<UiPrefab>>,
@@ -36,7 +35,6 @@ impl UiPrefabRegistry {
         })
     }
 }
-
 
 #[derive(Default)]
 pub struct CreaturePrefabs {

--- a/src/resources/prefabs.rs
+++ b/src/resources/prefabs.rs
@@ -1,13 +1,42 @@
 use std::collections::HashMap;
 use std::fs::read_dir;
 
+use crate::components::creatures::CreaturePrefabData;
 use amethyst::{
     assets::{AssetStorage, Handle, Prefab, PrefabLoader, ProgressCounter, RonFormat},
     ecs::World,
+    ui::{UiLoader, UiPrefab},
     utils::application_root_dir,
 };
 
-use crate::components::creatures::CreaturePrefabData;
+
+#[derive(Default)]
+pub struct UiPrefabRegistry {
+    pub prefabs: Vec<Handle<UiPrefab>>,
+}
+
+impl UiPrefabRegistry {
+    pub fn find(&self, world: &World, name: &str) -> Option<Handle<UiPrefab>> {
+        let storage = world.read_resource::<AssetStorage<UiPrefab>>();
+        self.prefabs.iter().find_map(|handle| {
+            if storage
+                .get(handle)?
+                .entities()
+                .next()?
+                .data()?
+                .0 // transform is 0th element of UiPrefab tuple
+                .as_ref()?
+                .id
+                == name
+            {
+                Some(handle.clone())
+            } else {
+                None
+            }
+        })
+    }
+}
+
 
 #[derive(Default)]
 pub struct CreaturePrefabs {
@@ -36,34 +65,61 @@ impl CreaturePrefabs {
     }
 }
 
+fn make_name(subdirectory: &str, entry: &std::fs::DirEntry) -> String {
+    let path_buffer = entry.path();
+    let filename = path_buffer.file_name().unwrap();
+    format!("{}{}", subdirectory, filename.to_str().unwrap())
+}
+
 // Here we load all prefabs for the different creatures in the game.
 // These prefabs are then stored in a resource of type CreaturePrefabs that is used by the spawner system.
 // At initialization time, we put temporary keys for the prefabs since they're not loaded yet.
 // When their loading is finished, we read the name of the entity inside to change the keys. This is done in the update_prefabs function.
 pub fn initialize_prefabs(world: &mut World) -> ProgressCounter {
-    let mut creature_prefabs = CreaturePrefabs::default();
     let mut progress_counter = ProgressCounter::new();
-    let prefab_iter = {
-        let prefab_dir_path = application_root_dir() + "/resources/prefabs/creatures";
-        let prefab_iter = read_dir(prefab_dir_path).unwrap();
-        prefab_iter.map(|prefab_dir_entry| {
-            world.exec(|loader: PrefabLoader<'_, CreaturePrefabData>| {
-                let prefab_path_buf = prefab_dir_entry.unwrap().path();
-                let prefab_filename = prefab_path_buf.file_name().unwrap();
-                loader.load(
-                    "prefabs/creatures/".to_string() + prefab_filename.to_str().unwrap(),
-                    RonFormat,
-                    (),
-                    &mut progress_counter,
-                )
-            })
-        })
-    };
 
-    for (count, prefab) in prefab_iter.enumerate() {
-        creature_prefabs.insert("temp_prefab_".to_string() + &count.to_string(), prefab);
+    // load ui prefabs
+    {
+        let mut ui_prefab_registry = UiPrefabRegistry::default();
+        let prefab_dir_path = application_root_dir() + "/resources/prefabs/ui";
+        let prefab_iter = read_dir(prefab_dir_path).unwrap();
+        ui_prefab_registry.prefabs = prefab_iter
+            .map(|prefab_dir_entry| {
+                world.exec(|loader: UiLoader<'_>| {
+                    loader.load(
+                        make_name("prefabs/ui/", &prefab_dir_entry.unwrap()),
+                        &mut progress_counter,
+                    )
+                })
+            })
+            .collect::<Vec<Handle<UiPrefab>>>();
+        world.add_resource(ui_prefab_registry);
     }
-    world.add_resource(creature_prefabs);
+
+    // load creature prefabs
+    {
+        let prefab_iter = {
+            let prefab_dir_path = application_root_dir() + "/resources/prefabs/creatures";
+            let prefab_iter = read_dir(prefab_dir_path).unwrap();
+            prefab_iter.map(|prefab_dir_entry| {
+                world.exec(|loader: PrefabLoader<'_, CreaturePrefabData>| {
+                    loader.load(
+                        make_name("prefabs/creatures/", &prefab_dir_entry.unwrap()),
+                        RonFormat,
+                        (),
+                        &mut progress_counter,
+                    )
+                })
+            })
+        };
+
+        let mut creature_prefabs = CreaturePrefabs::default();
+        for (count, prefab) in prefab_iter.enumerate() {
+            creature_prefabs.insert("temp_prefab_".to_string() + &count.to_string(), prefab);
+        }
+        world.add_resource(creature_prefabs);
+    }
+
     progress_counter
 }
 

--- a/src/states/loading.rs
+++ b/src/states/loading.rs
@@ -4,7 +4,7 @@ use crate::{
         prefabs::{initialize_prefabs, update_prefabs},
         world_bounds::WorldBounds,
     },
-    states::{menu::MenuState, CustomStateEvent},
+    states::{main_game::MainGameState, menu::MenuState, CustomStateEvent},
 };
 
 use crate::components::combat::load_factions;
@@ -13,6 +13,8 @@ use amethyst::{
     prelude::*,
     renderer::{DebugLines, DebugLinesParams},
 };
+
+const SKIP_MENU_ARG: &str = "no_menu";
 
 pub struct LoadingState {
     prefab_loading_progress: Option<ProgressCounter>,
@@ -50,7 +52,13 @@ impl<'a> State<GameData<'a, 'a>, CustomStateEvent> for LoadingState {
             if counter.is_complete() {
                 self.prefab_loading_progress = None;
                 update_prefabs(&mut data.world);
-                return Trans::Switch(Box::new(MenuState::default()));
+                use std::env;
+
+                if env::args().any(|arg| arg == SKIP_MENU_ARG) {
+                    return Trans::Switch(Box::new(MainGameState::new(data.world)));
+                } else {
+                    return Trans::Switch(Box::new(MenuState::default()));
+                }
             }
         }
 

--- a/src/states/loading.rs
+++ b/src/states/loading.rs
@@ -6,6 +6,7 @@ use crate::{
     },
     states::{main_game::MainGameState, menu::MenuState, CustomStateEvent},
 };
+use std::env;
 
 use crate::components::combat::load_factions;
 use amethyst::{
@@ -52,8 +53,6 @@ impl<'a> State<GameData<'a, 'a>, CustomStateEvent> for LoadingState {
             if counter.is_complete() {
                 self.prefab_loading_progress = None;
                 update_prefabs(&mut data.world);
-                use std::env;
-
                 if env::args().any(|arg| arg == SKIP_MENU_ARG) {
                     return Trans::Switch(Box::new(MainGameState::new(data.world)));
                 } else {

--- a/src/states/loading.rs
+++ b/src/states/loading.rs
@@ -4,7 +4,7 @@ use crate::{
         prefabs::{initialize_prefabs, update_prefabs},
         world_bounds::WorldBounds,
     },
-    states::{main_game::MainGameState, CustomStateEvent},
+    states::{menu::MenuState, CustomStateEvent},
 };
 
 use crate::components::combat::load_factions;
@@ -50,7 +50,7 @@ impl<'a> State<GameData<'a, 'a>, CustomStateEvent> for LoadingState {
             if counter.is_complete() {
                 self.prefab_loading_progress = None;
                 update_prefabs(&mut data.world);
-                return Trans::Switch(Box::new(MainGameState::new(data.world)));
+                return Trans::Switch(Box::new(MenuState::default()));
             }
         }
 

--- a/src/states/menu.rs
+++ b/src/states/menu.rs
@@ -1,0 +1,98 @@
+use crate::resources::prefabs::UiPrefabRegistry;
+use crate::states::{main_game::MainGameState, CustomStateEvent};
+use amethyst::{
+    ecs::{join::Join, Entity},
+    prelude::*,
+    ui::{UiEvent, UiEventType, UiTransform},
+};
+
+#[derive(Default)]
+pub struct MenuState {
+    // button entities are created in on_start() and destroyed in on_stop()
+    // if there is an invalid Entity that could be assigned to these by default, that'd be better than using Option
+    start_button: Option<Entity>,
+    exit_button: Option<Entity>,
+    root: Option<Entity>,
+}
+
+const MENU_ID: &str = "menu";
+const START_BUTTON_ID: &str = "start";
+const EXIT_BUTTON_ID: &str = "exit";
+
+// load the menu.ron prefab then instantiate it
+// if the "start" button is clicked, goto MainGameState
+// if the "exit" button is clicked, exit app
+impl<'a> State<GameData<'a, 'a>, CustomStateEvent> for MenuState {
+    fn on_start(&mut self, data: StateData<'_, GameData<'a, 'a>>) {
+        // assume UiPrefab loading has happened in a previous state
+        // look through the UiPrefabRegistry for the "menu" prefab and instantiate it
+        let menu_prefab = data
+            .world
+            .read_resource::<UiPrefabRegistry>()
+            .find(data.world, MENU_ID);
+        if let Some(unwrapped_menu) = menu_prefab {
+            eprintln!("instantiating main menu");
+            self.root = Some(data.world.create_entity().with(unwrapped_menu).build());
+        }
+    }
+
+    fn on_stop(&mut self, data: StateData<'_, GameData<'a, 'a>>) {
+        if let Some(root) = self.root {
+            if data.world.delete_entity(root).is_ok() {
+                self.root = None;
+            }
+        }
+        self.start_button = None;
+        self.exit_button = None;
+    }
+
+    fn handle_event(
+        &mut self,
+        data: StateData<GameData<'a, 'a>>,
+        event: CustomStateEvent,
+    ) -> Trans<GameData<'a, 'a>, CustomStateEvent> {
+        match event {
+            CustomStateEvent::Ui(UiEvent {
+                event_type: UiEventType::Click,
+                target,
+            }) => {
+                if Some(target) == self.start_button {
+                    eprintln!("start button clicked");
+                    Trans::Switch(Box::new(MainGameState::new(data.world)))
+                } else if Some(target) == self.exit_button {
+                    eprintln!("exit button clicked");
+                    Trans::Quit
+                } else {
+                    Trans::None
+                }
+            }
+            _ => Trans::None,
+        }
+    }
+
+    fn update(
+        &mut self,
+        data: StateData<'_, GameData<'a, 'a>>,
+    ) -> Trans<GameData<'a, 'a>, CustomStateEvent> {
+        data.data.update(&data.world);
+        // once deferred creation of the root ui entity finishes, look up buttons
+        if self.start_button.is_none() || self.exit_button.is_none() {
+            for (entity, transform) in (
+                &data.world.entities(),
+                &data.world.read_storage::<UiTransform>(),
+            )
+                .join()
+            {
+                if transform.id == START_BUTTON_ID {
+                    eprintln!("start button found");
+                    self.start_button = Some(entity);
+                } else if transform.id == EXIT_BUTTON_ID {
+                    eprintln!("exit button found");
+                    self.exit_button = Some(entity);
+                }
+            }
+        }
+
+        Trans::None
+    }
+}

--- a/src/states/menu.rs
+++ b/src/states/menu.rs
@@ -77,7 +77,7 @@ impl<'a> State<GameData<'a, 'a>, CustomStateEvent> for MenuState {
     ) -> Trans<GameData<'a, 'a>, CustomStateEvent> {
         data.data.update(&data.world);
         // once deferred creation of the root ui entity finishes, look up buttons
-        if self.start_button.is_none() || self.exit_button.is_none() { 
+        if self.start_button.is_none() || self.exit_button.is_none() {
             data.world.exec(|ui_finder: UiFinder<'_>| {
                 self.start_button = ui_finder.find(START_BUTTON_ID);
                 self.exit_button = ui_finder.find(EXIT_BUTTON_ID);

--- a/src/states/menu.rs
+++ b/src/states/menu.rs
@@ -26,6 +26,7 @@ impl<'a> State<GameData<'a, 'a>, CustomStateEvent> for MenuState {
     fn on_start(&mut self, data: StateData<'_, GameData<'a, 'a>>) {
         // assume UiPrefab loading has happened in a previous state
         // look through the UiPrefabRegistry for the "menu" prefab and instantiate it
+        eprintln!("start main menu");
         let menu_prefab = data
             .world
             .read_resource::<UiPrefabRegistry>()
@@ -76,10 +77,11 @@ impl<'a> State<GameData<'a, 'a>, CustomStateEvent> for MenuState {
     ) -> Trans<GameData<'a, 'a>, CustomStateEvent> {
         data.data.update(&data.world);
         // once deferred creation of the root ui entity finishes, look up buttons
-        if self.start_button.is_none() || self.exit_button.is_none() {
-            let ui_finder = data.world.read_resource::<UiFinder>();
-            self.start_button = ui_finder.find(START_BUTTON_ID);
-            self.exit_button = ui_finder.find(EXIT_BUTTON_ID);
+        if self.start_button.is_none() || self.exit_button.is_none() { 
+            data.world.exec(|ui_finder: UiFinder<'_>| {
+                self.start_button = ui_finder.find(START_BUTTON_ID);
+                self.exit_button = ui_finder.find(EXIT_BUTTON_ID);
+            });
         }
         Trans::None
     }

--- a/src/states/menu.rs
+++ b/src/states/menu.rs
@@ -1,9 +1,9 @@
 use crate::resources::prefabs::UiPrefabRegistry;
 use crate::states::{main_game::MainGameState, CustomStateEvent};
 use amethyst::{
-    ecs::{join::Join, Entity},
+    ecs::Entity,
     prelude::*,
-    ui::{UiEvent, UiEventType, UiTransform},
+    ui::{UiEvent, UiEventType, UiFinder},
 };
 
 #[derive(Default)]
@@ -77,22 +77,10 @@ impl<'a> State<GameData<'a, 'a>, CustomStateEvent> for MenuState {
         data.data.update(&data.world);
         // once deferred creation of the root ui entity finishes, look up buttons
         if self.start_button.is_none() || self.exit_button.is_none() {
-            for (entity, transform) in (
-                &data.world.entities(),
-                &data.world.read_storage::<UiTransform>(),
-            )
-                .join()
-            {
-                if transform.id == START_BUTTON_ID {
-                    eprintln!("start button found");
-                    self.start_button = Some(entity);
-                } else if transform.id == EXIT_BUTTON_ID {
-                    eprintln!("exit button found");
-                    self.exit_button = Some(entity);
-                }
-            }
+            let ui_finder = data.world.read_resource::<UiFinder>();
+            self.start_button = ui_finder.find(START_BUTTON_ID);
+            self.exit_button = ui_finder.find(EXIT_BUTTON_ID);
         }
-
         Trans::None
     }
 }

--- a/src/states/mod.rs
+++ b/src/states/mod.rs
@@ -1,5 +1,6 @@
 pub mod loading;
 pub mod main_game;
+pub mod menu;
 pub mod paused;
 
 use amethyst::{


### PR DESCRIPTION
https://github.com/amethyst/evoli/issues/48

Added menu.rs, the menu state.
Added UiPrefab loading to prefabs.rs. UiPrefab loading happens at the same time as main game assets.
Modified state flow to go from loading to menu to main_game.
Added resources/prefabs/ui/menu.ron, the menu prefab asset.