### PR TITLE
Avoid divide-by-zero in SeekSystem

### DIFF
--- a/src/systems/behaviors/decision.rs
+++ b/src/systems/behaviors/decision.rs
@@ -192,6 +192,9 @@ where
     fn run(&mut self, (_entities, closest_things, time, mut movements): Self::SystemData) {
         let delta_time = time.delta_seconds();
         for (movement, closest) in (&mut movements, &closest_things).join() {
+            if (closest.distance.norm() == 0.0) {
+                continue;
+            }
             let target_velocity = closest.distance.normalize() * self.attraction_magnitude;
             let steering_force = target_velocity - movement.velocity;
             movement.velocity += self.attraction_modifier * steering_force * delta_time;

--- a/src/systems/behaviors/decision.rs
+++ b/src/systems/behaviors/decision.rs
@@ -192,7 +192,7 @@ where
     fn run(&mut self, (_entities, closest_things, time, mut movements): Self::SystemData) {
         let delta_time = time.delta_seconds();
         for (movement, closest) in (&mut movements, &closest_things).join() {
-            if (closest.distance.norm() == 0.0) {
+            if closest.distance.norm() == 0.0 {
                 continue;
             }
             let target_velocity = closest.distance.normalize() * self.attraction_magnitude;


### PR DESCRIPTION
Normalizing the vector when the magnitude is 0 will result in a divide by zero, leading to invalid velocities that break things elsewhere in the program (I dunno why this doesn't trigger floating point exceptions before leading to these problems, tho? haven't looked into it)