### PR TITLE
Add carcasses on death events

### DIFF
--- a/resources/assets/carcass.glb
+++ b/resources/assets/carcass.glb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0b0ac83f39e639f6996b88bcd244f6a47d9221144d50fb529dcbd17017a298fb
+size 25620

--- a/resources/prefabs/creatures/carnivore.ron
+++ b/resources/prefabs/creatures/carnivore.ron
@@ -27,9 +27,6 @@ Prefab (
                         max: 100.0,
                         value: 100.0,
                     ),
-                    nutrition: (
-                        value: 50.0,
-                    )
                 ),
                 combat: (
                     health: (

--- a/resources/prefabs/creatures/herbivore.ron
+++ b/resources/prefabs/creatures/herbivore.ron
@@ -27,9 +27,6 @@ Prefab (
                         max: 100.0,
                         value: 100.0,
                     ),
-                    nutrition: (
-                        value: 50.0,
-                    ),
                 ),
                 combat: (
                     health: (
@@ -49,6 +46,9 @@ Prefab (
                 intelligence_tag: (),
                 perception: (
                     range: 2.5,
+                ),
+                carcass: (
+                    creature_type: "HerbivoreCarcass"
                 ),
             ),
         ),

--- a/resources/prefabs/creatures/herbivore_carcass.ron
+++ b/resources/prefabs/creatures/herbivore_carcass.ron
@@ -1,0 +1,38 @@
+#![enable(implicit_some)]
+Prefab (
+    entities: [
+        (
+            data: (
+                name: (
+                    name: "HerbivoreCarcass"
+                ),
+                creature_tag: (),
+                gltf: File("assets/carcass.glb", ()),
+                collider: (
+                    radius: 0.45,
+                ),
+                digestion: (
+                    digestion: (
+                        nutrition_burn_rate: 5.0,
+                    ),
+                    fullness: (
+                        max: 100.0,
+                        value: 100.0,
+                    ),
+                    nutrition: (
+                        value: 50.0,
+                    ),
+                ),
+                combat: (
+                    health: (
+                        max_health: 50.0,
+                        value: 50.0,
+                    ),
+                    has_faction: (
+                        faction: "Herbivores",
+                    ),
+                ),
+            ),
+        ),
+    ],
+)

--- a/src/components/creatures.rs
+++ b/src/components/creatures.rs
@@ -77,6 +77,16 @@ impl Wander {
     }
 }
 
+#[derive(Clone, Debug, Default, Deserialize, Serialize, PrefabData)]
+#[prefab(Component)]
+pub struct Carcass {
+    pub creature_type: CreatureType,
+}
+
+impl Component for Carcass {
+    type Storage = DenseVecStorage<Self>;
+}
+
 // This is the main prefab data for creatures.
 // It defines all the components that a creature could have.
 // In the prefab, it is not necessary to define all of them (due to Option).
@@ -96,4 +106,5 @@ pub struct CreaturePrefabData {
     intelligence_tag: Option<IntelligenceTag>,
     perception: Option<Perception>,
     ricochet_tag: Option<RicochetTag>,
+    carcass: Option<Carcass>,
 }

--- a/src/components/digestion.rs
+++ b/src/components/digestion.rs
@@ -46,5 +46,5 @@ impl Component for Nutrition {
 pub struct DigestionPrefabData {
     fullness: Fullness,
     digestion: Digestion,
-    nutrition: Nutrition,
+    nutrition: Option<Nutrition>,
 }

--- a/src/states/main_game.rs
+++ b/src/states/main_game.rs
@@ -141,7 +141,7 @@ impl MainGameState {
                 )
                 .with(digestion::DigestionSystem, "digestion_system", &[])
                 .with(
-                    digestion::StarvationSystem,
+                    death::StarvationSystem,
                     "starvation_system",
                     &["digestion_system"],
                 )
@@ -157,9 +157,14 @@ impl MainGameState {
                     &["find_attack_system"],
                 )
                 .with(
-                    health::DeathByHealthSystem,
+                    death::DeathByHealthSystem,
                     "death_by_health_system",
                     &["perform_default_attack_system"],
+                )
+                .with(
+                    death::CarcassSystem::default(),
+                    "carcass_system",
+                    &["death_by_health_system"],
                 )
                 .with(
                     spawner::DebugSpawnTriggerSystem::default(),

--- a/src/systems/death.rs
+++ b/src/systems/death.rs
@@ -1,0 +1,93 @@
+use amethyst::{core::transform::Transform, ecs::*, shrev::EventChannel};
+use std::f32;
+
+use crate::components::{combat::Health, creatures::Carcass, digestion::Fullness};
+use crate::systems::spawner::CreatureSpawnEvent;
+
+#[derive(Debug, Clone)]
+pub struct CreatureDeathEvent {
+    pub deceased: Entity,
+}
+
+pub struct StarvationSystem;
+
+// Entities die if their fullness reaches zero (or less).
+impl<'s> System<'s> for StarvationSystem {
+    type SystemData = (
+        ReadStorage<'s, Fullness>,
+        Entities<'s>,
+        Write<'s, EventChannel<CreatureDeathEvent>>,
+    );
+
+    fn run(&mut self, (fullnesses, entities, mut death_events): Self::SystemData) {
+        for (fullness, entity) in (&fullnesses, &*entities).join() {
+            if fullness.value < f32::EPSILON {
+                death_events.single_write(CreatureDeathEvent { deceased: entity });
+                let _ = entities.delete(entity);
+            }
+        }
+    }
+}
+
+pub struct DeathByHealthSystem;
+
+// Entities die if their health reaches zero (or less).
+impl<'s> System<'s> for DeathByHealthSystem {
+    type SystemData = (
+        ReadStorage<'s, Health>,
+        Entities<'s>,
+        Write<'s, EventChannel<CreatureDeathEvent>>,
+    );
+
+    fn run(&mut self, (healths, entities, mut death_events): Self::SystemData) {
+        for (health, entity) in (&healths, &*entities).join() {
+            if health.value < f32::EPSILON {
+                death_events.single_write(CreatureDeathEvent { deceased: entity });
+                let _ = entities.delete(entity);
+            }
+        }
+    }
+}
+
+#[derive(Default)]
+pub struct CarcassSystem {
+    death_reader_id: Option<ReaderId<CreatureDeathEvent>>,
+}
+
+impl<'s> System<'s> for CarcassSystem {
+    type SystemData = (
+        Entities<'s>,
+        Read<'s, EventChannel<CreatureDeathEvent>>,
+        Write<'s, EventChannel<CreatureSpawnEvent>>,
+        Write<'s, LazyUpdate>,
+        ReadStorage<'s, Transform>,
+        ReadStorage<'s, Carcass>,
+    );
+
+    fn setup(&mut self, res: &mut Resources) {
+        Self::SystemData::setup(res);
+        self.death_reader_id = Some(
+            res.fetch_mut::<EventChannel<CreatureDeathEvent>>()
+                .register_reader(),
+        );
+    }
+
+    fn run(
+        &mut self,
+        (entities, death_events, mut spawn_events, lazy_update, transforms, carcasses): Self::SystemData,
+    ) {
+        for event in death_events.read(self.death_reader_id.as_mut().unwrap()) {
+            let mut deceased = BitSet::new();
+            deceased.add(event.deceased.id());
+
+            for (_, carcass, transform) in (&deceased, &carcasses, &transforms).join() {
+                let creature_entity_builder =
+                    lazy_update.create_entity(&entities).with(transform.clone());
+                spawn_events.single_write(CreatureSpawnEvent {
+                    creature_type: carcass.creature_type.clone(),
+                    entity: creature_entity_builder.build(),
+                });
+            }
+        }
+    }
+}

--- a/src/systems/digestion.rs
+++ b/src/systems/digestion.rs
@@ -1,6 +1,5 @@
 use amethyst::renderer::{debug_drawing::DebugLines, palette::Srgba};
 use amethyst::{core::Time, core::Transform, ecs::*};
-use std::f32;
 
 use crate::components::digestion::{Digestion, Fullness};
 
@@ -19,21 +18,6 @@ impl<'s> System<'s> for DigestionSystem {
             let burned = digestion.nutrition_burn_rate * delta_time;
             let new_value = fullness.value - burned;
             fullness.value = new_value;
-        }
-    }
-}
-
-pub struct StarvationSystem;
-
-// Entities die if their fullness reaches zero (or less).
-impl<'s> System<'s> for StarvationSystem {
-    type SystemData = (ReadStorage<'s, Fullness>, Entities<'s>);
-
-    fn run(&mut self, (fullnesses, entities): Self::SystemData) {
-        for (fullness, entity) in (&fullnesses, &*entities).join() {
-            if fullness.value < f32::EPSILON {
-                let _ = entities.delete(entity);
-            }
         }
     }
 }

--- a/src/systems/health.rs
+++ b/src/systems/health.rs
@@ -3,24 +3,8 @@ use amethyst::{
     ecs::*,
     renderer::{debug_drawing::DebugLinesComponent, palette::Srgba},
 };
-use std::f32;
 
 use crate::components::combat::Health;
-
-pub struct DeathByHealthSystem;
-
-// Entities die if their health reaches zero (or less).
-impl<'s> System<'s> for DeathByHealthSystem {
-    type SystemData = (ReadStorage<'s, Health>, Entities<'s>);
-
-    fn run(&mut self, (healths, entities): Self::SystemData) {
-        for (health, entity) in (&healths, &*entities).join() {
-            if health.value < f32::EPSILON {
-                let _ = entities.delete(entity);
-            }
-        }
-    }
-}
 
 #[derive(Default)]
 pub struct DebugHealthSystem {}

--- a/src/systems/mod.rs
+++ b/src/systems/mod.rs
@@ -2,6 +2,7 @@ pub mod behaviors;
 pub mod camera_movement;
 pub mod collision;
 pub mod combat;
+pub mod death;
 pub mod debug;
 pub mod digestion;
 pub mod health;


### PR DESCRIPTION
Resolves #103 

Add a death event that triggers on starvation and death by
health loss. If the dying entity has a new carcass component, spawn
an entity of the creature type held in that component. Remove
nutrtition to fullness transfer on attack death, and instead decrease
nutrition of the attacked by the attack damage of the attacker. This
allows for entities that do not spawn carcasses (i.e. plants) to still
provide nutrition to their attacker, and prevents live creatures
(i.e. herbivores) that do spawn carcasses from providing any nutrition
while alive.