### PR TITLE
Fix filename in prefab to start with lowercase

### DIFF
--- a/resources/prefabs/creatures/topplegrass.ron
+++ b/resources/prefabs/creatures/topplegrass.ron
@@ -6,7 +6,7 @@ Prefab (
                 name: (
                     name: "Topplegrass"
                 ),
-                gltf: File("assets/Topplegrass.gltf", ()),
+                gltf: File("assets/topplegrass.gltf", ()),
                 movement: (
                     velocity: [0.0, 0.0, 0.0],
                     max_movement_speed: 10.0,


### PR DESCRIPTION
This fixes the issue reported by gtors at https://github.com/amethyst/evoli/issues/106#issuecomment-586713995

The issue went unnoticed before now because the game was only tested on Windows machines, which are not case-sensitive for filenames.