### PR TITLE
Fix loading Wind resource from config file

### DIFF
--- a/src/resources/experimental/wind.rs
+++ b/src/resources/experimental/wind.rs
@@ -20,6 +20,6 @@ impl Wind {
 
 impl Default for Wind {
     fn default() -> Self {
-        Wind::new(0.0, 0.0)
+        Wind::new(2.0, 0.0)
     }
 }

--- a/src/states/loading.rs
+++ b/src/states/loading.rs
@@ -52,7 +52,10 @@ impl SimpleState for LoadingState {
         data.world
             .insert(WorldBounds::new(-10.0, 10.0, -10.0, 10.0));
         let wind_config_path = self.config_path.clone() + "/wind.ron";
-        let wind_config = Wind::load(wind_config_path);
+        let wind_config = Wind::load(wind_config_path).unwrap_or_else(|error| {
+            error!("Failed to load wind resource from config file. Using Wind::default() instead. Error: {:?}", error);
+            Wind::default()
+        });
         data.world.insert(wind_config);
     }
 


### PR DESCRIPTION
This fixes a bug that caused the Wind config file to always be ignored. As a result, the wind was always zero at the start of the game and topplegrass entities never move after they spawn. 

After the resource is loaded, it is not unwrapped before it is inserted into the world. Amethyst later automatically adds the resource by calling default(). 

To fix this, the result is unwrapped. Additionally, if the loading failed, this is logged as an error but a fallback is used to prevent the game from crashing.